### PR TITLE
Add top variable to limit the maximum annual flow of tokens per vest

### DIFF
--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -27,8 +27,7 @@ contract DssVest {
 
     address public   immutable gem;
 
-    uint256 internal constant  ONE_YEAR = 365 days;
-    uint256 public   constant  TWENTY_YEARS = 20 * ONE_YEAR;
+    uint256 public   constant  TWENTY_YEARS = 20 * 365 days;
     uint256 internal constant  WAD = 10**18;
 
     uint256 internal locked;

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -113,7 +113,7 @@ contract DssVest {
         require(_bgn < add(block.timestamp, TWENTY_YEARS), "DssVest/bgn-too-far");
         require(_bgn > sub(block.timestamp, TWENTY_YEARS), "DssVest/bgn-too-long-ago");
         require(_tau > 0,                                  "DssVest/tau-zero");
-        require(_tot / _tau * ONE_YEAR <= top,             "DssVest/tot-too-high");
+        require(_tot / _tau <= top / 365 days,             "DssVest/tot-too-high");
         require(_tau <= TWENTY_YEARS,                      "DssVest/tau-too-long");
         require(_clf <= _tau,                              "DssVest/clf-too-long");
         require(id < uint256(-1),                          "DssVest/id-overflow");

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -69,12 +69,12 @@ contract DssVest {
     mapping (uint256 => Award) public awards;
     uint256 public ids;
 
-    uint256 public top; // Maximum annual tokens that can be disbursed [wad]
+    uint256 public cap; // Maximum per-second issuance token rate
 
     // This contract must be authorized to 'mint' on the token
-    constructor(address _gem, uint256 _top) public {
+    constructor(address _gem, uint256 _cap) public {
         gem = _gem;
-        top = _top;
+        cap = _cap;
         wards[msg.sender] = 1;
         emit Rely(msg.sender);
     }
@@ -112,7 +112,7 @@ contract DssVest {
         require(_bgn < add(block.timestamp, TWENTY_YEARS), "DssVest/bgn-too-far");
         require(_bgn > sub(block.timestamp, TWENTY_YEARS), "DssVest/bgn-too-long-ago");
         require(_tau > 0,                                  "DssVest/tau-zero");
-        require(_tot / _tau <= top / 365 days,             "DssVest/tot-too-high");
+        require(_tot / _tau <= cap,                        "DssVest/tot-too-high");
         require(_tau <= TWENTY_YEARS,                      "DssVest/tau-too-long");
         require(_clf <= _tau,                              "DssVest/clf-too-long");
         require(id < uint256(-1),                          "DssVest/id-overflow");
@@ -226,7 +226,7 @@ contract DssVest {
     }
 
     function file(bytes32 what, uint256 data) external auth {
-        if      (what == "top")         top = data;     // The maximum amount of tokens that can be streamed per year per vest
+        if      (what == "cap")         cap = data;     // The maximum amount of tokens that can be streamed per-second per vest
         else revert("DssVest/file-unrecognized-param");
         emit File(what, data);
     }

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -228,7 +228,7 @@ contract DssVest {
 
     function file(bytes32 what, uint256 data) external auth {
         if      (what == "top")         top = data;     // The maximum amount of tokens that can be streamed per year per vest
-        else revert("Clipper/file-unrecognized-param");
+        else revert("DssVest/file-unrecognized-param");
         emit File(what, data);
     }
 

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -112,7 +112,7 @@ contract DssVest {
         require(_bgn < add(block.timestamp, TWENTY_YEARS), "DssVest/bgn-too-far");
         require(_bgn > sub(block.timestamp, TWENTY_YEARS), "DssVest/bgn-too-long-ago");
         require(_tau > 0,                                  "DssVest/tau-zero");
-        require(_tot / _tau <= cap,                        "DssVest/tot-too-high");
+        require(_tot / _tau <= cap,                        "DssVest/rate-too-high");
         require(_tau <= TWENTY_YEARS,                      "DssVest/tau-too-long");
         require(_clf <= _tau,                              "DssVest/clf-too-long");
         require(id < uint256(-1),                          "DssVest/id-overflow");

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -41,7 +41,7 @@ contract DssVestTest is DSTest {
 
     function setUp() public {
         hevm = Hevm(address(CHEAT_CODE));
-        vest = new DssVest(MKR_TOKEN);
+        vest = new DssVest(MKR_TOKEN, 500 * WAD);
 
         // Set testing contract as a MKR Auth
         hevm.store(
@@ -53,7 +53,7 @@ contract DssVestTest is DSTest {
     }
 
     function testCost() public {
-        new DssVest(MKR_TOKEN);
+        new DssVest(MKR_TOKEN, 500 * WAD);
     }
 
     function testInit() public {
@@ -431,5 +431,21 @@ contract DssVestTest is DSTest {
 
     function testFailClfAfterTau() public {
         vest.init(address(this), 100 * days_vest + 1, block.timestamp, 100 days, 101 days, address(0));
+    }
+
+    function testTop() public {
+        // Test init at top limit
+        uint256 id = vest.init(address(this), 500 * WAD, block.timestamp, 365 days, 0, address(0));
+        assertEq(id, 1);
+
+        vest.file("top", 1000 * WAD);
+
+        id = vest.init(address(this), 1000 * WAD, block.timestamp, 365 days, 0, address(0));
+        assertEq(id, 2);
+    }
+
+    function testFailTop() public {
+        // Test failure at 1 over limit
+        vest.init(address(this), 501 * WAD, block.timestamp, 365 days, 0, address(0));
     }
 }

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -41,7 +41,7 @@ contract DssVestTest is DSTest {
 
     function setUp() public {
         hevm = Hevm(address(CHEAT_CODE));
-        vest = new DssVest(MKR_TOKEN, 500 * WAD);
+        vest = new DssVest(MKR_TOKEN, (2000 * WAD) / (4 * 365 days));
 
         // Set testing contract as a MKR Auth
         hevm.store(
@@ -433,18 +433,18 @@ contract DssVestTest is DSTest {
         vest.init(address(this), 100 * days_vest + 1, block.timestamp, 100 days, 101 days, address(0));
     }
 
-    function testTop() public {
+    function testCap() public {
         // Test init at top limit
         uint256 id = vest.init(address(this), 500 * WAD, block.timestamp, 365 days, 0, address(0));
         assertEq(id, 1);
 
-        vest.file("top", 1000 * WAD);
+        vest.file("cap", (4000 * WAD) / (4 * 365 days));
 
         id = vest.init(address(this), 1000 * WAD, block.timestamp, 365 days, 0, address(0));
         assertEq(id, 2);
     }
 
-    function testFailTop() public {
+    function testFailCap() public {
         // Test failure at 1 over limit
         vest.init(address(this), 501 * WAD, block.timestamp, 365 days, 0, address(0));
     }

--- a/src/fuzz/DssVestEchidnaTest.sol
+++ b/src/fuzz/DssVestEchidnaTest.sol
@@ -65,8 +65,7 @@ contract DssVestEchidnaTest {
 
     function test_vest(uint256 id) internal {
         vest.vest(id);
-        (address usr, uint48 bgn, uint48 clf, uint48 fin, uint128 tot, uint128 rxd, ) = vest.awards(id);
-        usr;
+        (, uint48 bgn, uint48 clf, uint48 fin, uint128 tot, uint128 rxd, ) = vest.awards(id);
         uint256 amt = vest.unpaid(id);
         if (block.timestamp < clf) assert(amt == 0);
         else if (block.timestamp < bgn) assert(amt == rxd);

--- a/src/fuzz/DssVestEchidnaTest.sol
+++ b/src/fuzz/DssVestEchidnaTest.sol
@@ -13,7 +13,7 @@ contract DssVestEchidnaTest {
     uint256 internal immutable salt;
 
     constructor() public {
-      vest = new DssVest(address(GEM));
+      vest = new DssVest(address(GEM), 500 * WAD);
       vest.rely(address(this));
       salt = block.timestamp;
     }
@@ -66,6 +66,7 @@ contract DssVestEchidnaTest {
     function test_vest(uint256 id) internal {
         vest.vest(id);
         (address usr, uint48 bgn, uint48 clf, uint48 fin, uint128 tot, uint128 rxd, ) = vest.awards(id);
+        usr;
         uint256 amt = vest.unpaid(id);
         if (block.timestamp < clf) assert(amt == 0);
         else if (block.timestamp < bgn) assert(amt == rxd);


### PR DESCRIPTION
Rate limit the maximum amount of tokens that can be issued per year, per vest