### PR TITLE
Add Support for Payments through vat.suck

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/ds-test"]
 	path = lib/ds-test
 	url = https://github.com/dapphub/ds-test
+[submodule "lib/dss-interfaces"]
+	path = lib/dss-interfaces
+	url = https://github.com/makerdao/dss-interfaces

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "lib/ds-test"]
 	path = lib/ds-test
 	url = https://github.com/dapphub/ds-test
-[submodule "lib/dss-interfaces"]
-	path = lib/dss-interfaces
-	url = https://github.com/makerdao/dss-interfaces

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -19,9 +19,8 @@
 
 pragma solidity 0.6.12;
 
-interface IERC20 {
+interface MintLike {
     function mint(address, uint256) external;
-    function balanceOf(address) external view returns (uint256);
 }
 
 interface ChainlogLike {
@@ -34,9 +33,7 @@ interface DaiJoinLike {
 
 interface VatLike {
     function hope(address) external;
-    function wards(address) external view returns (uint256);
     function suck(address, address, uint256) external;
-    function sin(address) external view returns (uint256);
 }
 
 abstract contract DssVest {
@@ -274,11 +271,11 @@ abstract contract DssVest {
 
 contract DssVestMintable is DssVest {
 
-    IERC20 public immutable gem;
+    MintLike public immutable gem;
 
     // This contract must be authorized to 'mint' on the token
     constructor(address _gem, uint256 _cap) public DssVest(_cap) {
-        gem = IERC20(_gem);
+        gem = MintLike(_gem);
     }
 
     function pay(address _guy, uint256 _amt) override internal {
@@ -298,10 +295,10 @@ contract DssVestSuckable is DssVest {
     // This contract must be authorized to 'suck' on the vat
     constructor(address _chainlog, uint256 _cap) public DssVest(_cap) {
         chainlog = ChainlogLike(_chainlog);
-        vat = VatLike(ChainlogLike(_chainlog).getAddress("MCD_VAT"));
-        daiJoin = DaiJoinLike(ChainlogLike(_chainlog).getAddress("MCD_JOIN_DAI"));
+        VatLike _vat = vat = VatLike(ChainlogLike(_chainlog).getAddress("MCD_VAT"));
+        DaiJoinLike _daiJoin = daiJoin = DaiJoinLike(ChainlogLike(_chainlog).getAddress("MCD_JOIN_DAI"));
 
-        VatLike(ChainlogLike(_chainlog).getAddress("MCD_VAT")).hope(ChainlogLike(_chainlog).getAddress("MCD_JOIN_DAI"));
+        _vat.hope(address(_daiJoin));
     }
 
     function pay(address _guy, uint256 _amt) override internal {

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -19,10 +19,25 @@
 
 pragma solidity 0.6.12;
 
-import "dss-interfaces/dapp/DSTokenAbstract.sol";
-import "dss-interfaces/dss/ChainlogAbstract.sol";
-import "dss-interfaces/dss/DaiJoinAbstract.sol";
-import "dss-interfaces/dss/VatAbstract.sol";
+interface IERC20 {
+    function mint(address, uint256) external;
+    function balanceOf(address) external view returns (uint256);
+}
+
+interface ChainlogLike {
+    function getAddress(bytes32) external view returns (address);
+}
+
+interface DaiJoinLike {
+    function exit(address, uint256) external;
+}
+
+interface VatLike {
+    function hope(address) external;
+    function wards(address) external view returns (uint256);
+    function suck(address, address, uint256) external;
+    function sin(address) external view returns (uint256);
+}
 
 abstract contract DssVest {
 
@@ -247,11 +262,11 @@ abstract contract DssVest {
 
 contract DssVestMintable is DssVest {
 
-    DSTokenAbstract public immutable gem;
+    IERC20 public immutable gem;
 
     // This contract must be authorized to 'mint' on the token
     constructor(address _gem) public DssVest() {
-        gem = DSTokenAbstract(_gem);
+        gem = IERC20(_gem);
     }
 
     function pay(address _guy, uint256 _amt) override internal {
@@ -264,17 +279,17 @@ contract DssVestSuckable is DssVest {
 
     uint256 internal constant RAY = 10**27;
 
-    ChainlogAbstract public immutable chainlog;
-    VatAbstract      public immutable vat;
-    DaiJoinAbstract  public immutable daiJoin;
+    ChainlogLike public immutable chainlog;
+    VatLike      public immutable vat;
+    DaiJoinLike  public immutable daiJoin;
 
     // This contract must be authorized to 'suck' on the vat
     constructor(address _chainlog) public DssVest() {
-        chainlog = ChainlogAbstract(_chainlog);
-        vat = VatAbstract(ChainlogAbstract(_chainlog).getAddress("MCD_VAT"));
-        daiJoin = DaiJoinAbstract(ChainlogAbstract(_chainlog).getAddress("MCD_JOIN_DAI"));
+        chainlog = ChainlogLike(_chainlog);
+        vat = VatLike(ChainlogLike(_chainlog).getAddress("MCD_VAT"));
+        daiJoin = DaiJoinLike(ChainlogLike(_chainlog).getAddress("MCD_JOIN_DAI"));
 
-        VatAbstract(ChainlogAbstract(_chainlog).getAddress("MCD_VAT")).hope(ChainlogAbstract(_chainlog).getAddress("MCD_JOIN_DAI"));
+        VatLike(ChainlogLike(_chainlog).getAddress("MCD_VAT")).hope(ChainlogLike(_chainlog).getAddress("MCD_JOIN_DAI"));
     }
 
     function pay(address _guy, uint256 _amt) override internal {

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -27,9 +27,15 @@ contract Manager {
 
 contract DssVestTest is DSTest {
     Hevm hevm;
-    DssVest vest;
+    DssVestMintable vest;
+    DssVestSuckable suckableVest;
 
     address constant MKR_TOKEN = 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2;
+    address constant CHAINLOG = 0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F;
+    address constant VAT = 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B;
+    address constant DAI_JOIN = 0x9759A6Ac90977b93B58547b4A71c78317f391A28;
+    address constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address constant VOW = 0xA950524441892A31ebddF91d3cEEFa04Bf454466;
     uint256 constant WAD = 10**18;
     uint256 constant days_vest = WAD;
 
@@ -41,7 +47,8 @@ contract DssVestTest is DSTest {
 
     function setUp() public {
         hevm = Hevm(address(CHEAT_CODE));
-        vest = new DssVest(MKR_TOKEN);
+        vest = new DssVestMintable(MKR_TOKEN);
+        suckableVest = new DssVestSuckable(CHAINLOG);
 
         // Set testing contract as a MKR Auth
         hevm.store(
@@ -50,10 +57,18 @@ contract DssVestTest is DSTest {
             bytes32(uint256(1))
         );
         assertEq(GovGuard(GOV_GUARD).wards(address(vest)), 1);
+
+        // Give admin access to vat
+        hevm.store(
+            address(VAT),
+            keccak256(abi.encode(address(suckableVest), uint256(0))),
+            bytes32(uint256(1))
+        );
+        assertEq(VatAbstract(VAT).wards(address(suckableVest)), 1);
     }
 
     function testCost() public {
-        new DssVest(MKR_TOKEN);
+        new DssVestMintable(MKR_TOKEN);
     }
 
     function testInit() public {
@@ -431,5 +446,19 @@ contract DssVestTest is DSTest {
 
     function testFailClfAfterTau() public {
         vest.init(address(this), 100 * days_vest + 1, block.timestamp, 100 days, 101 days, address(0));
+    }
+
+    function testSuckableVest() public {
+        uint256 id = suckableVest.init(address(this), 100 * days_vest, block.timestamp, 100 days, 0, address(0));
+        assertTrue(suckableVest.valid(id));
+        hevm.warp(block.timestamp + 1 days);
+        suckableVest.vest(id);
+        assertEq(DSTokenAbstract(DAI).balanceOf(address(this)), 1 * days_vest);
+        hevm.warp(block.timestamp + 9 days);
+        suckableVest.vest(id);
+        assertEq(DSTokenAbstract(DAI).balanceOf(address(this)), 10 * days_vest);
+        hevm.warp(block.timestamp + 365 days);
+        suckableVest.vest(id);
+        assertEq(DSTokenAbstract(DAI).balanceOf(address(this)), 100 * days_vest);
     }
 }

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -65,7 +65,7 @@ contract DssVestTest is DSTest {
             keccak256(abi.encode(address(suckableVest), uint256(0))),
             bytes32(uint256(1))
         );
-        assertEq(VatAbstract(VAT).wards(address(suckableVest)), 1);
+        assertEq(VatLike(VAT).wards(address(suckableVest)), 1);
     }
 
     function testCost() public {
@@ -450,20 +450,20 @@ contract DssVestTest is DSTest {
     }
 
     function testSuckableVest() public {
-        uint256 originalSin = VatAbstract(VAT).sin(VOW);
+        uint256 originalSin = VatLike(VAT).sin(VOW);
         uint256 id = suckableVest.init(address(this), 100 * days_vest, block.timestamp, 100 days, 0, address(0));
         assertTrue(suckableVest.valid(id));
         hevm.warp(block.timestamp + 1 days);
         suckableVest.vest(id);
-        assertEq(DSTokenAbstract(DAI).balanceOf(address(this)), 1 * days_vest);
-        assertEq(VatAbstract(VAT).sin(VOW), originalSin + 1 * days_vest * RAY);
+        assertEq(IERC20(DAI).balanceOf(address(this)), 1 * days_vest);
+        assertEq(VatLike(VAT).sin(VOW), originalSin + 1 * days_vest * RAY);
         hevm.warp(block.timestamp + 9 days);
         suckableVest.vest(id);
-        assertEq(DSTokenAbstract(DAI).balanceOf(address(this)), 10 * days_vest);
-        assertEq(VatAbstract(VAT).sin(VOW), originalSin + 10 * days_vest * RAY);
+        assertEq(IERC20(DAI).balanceOf(address(this)), 10 * days_vest);
+        assertEq(VatLike(VAT).sin(VOW), originalSin + 10 * days_vest * RAY);
         hevm.warp(block.timestamp + 365 days);
         suckableVest.vest(id);
-        assertEq(DSTokenAbstract(DAI).balanceOf(address(this)), 100 * days_vest);
-        assertEq(VatAbstract(VAT).sin(VOW), originalSin + 100 * days_vest * RAY);
+        assertEq(IERC20(DAI).balanceOf(address(this)), 100 * days_vest);
+        assertEq(VatLike(VAT).sin(VOW), originalSin + 100 * days_vest * RAY);
     }
 }

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -37,6 +37,7 @@ contract DssVestTest is DSTest {
     address constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
     address constant VOW = 0xA950524441892A31ebddF91d3cEEFa04Bf454466;
     uint256 constant WAD = 10**18;
+    uint256 constant RAY = 10**27;
     uint256 constant days_vest = WAD;
 
     // CHEAT_CODE = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D
@@ -449,16 +450,20 @@ contract DssVestTest is DSTest {
     }
 
     function testSuckableVest() public {
+        uint256 originalSin = VatAbstract(VAT).sin(VOW);
         uint256 id = suckableVest.init(address(this), 100 * days_vest, block.timestamp, 100 days, 0, address(0));
         assertTrue(suckableVest.valid(id));
         hevm.warp(block.timestamp + 1 days);
         suckableVest.vest(id);
         assertEq(DSTokenAbstract(DAI).balanceOf(address(this)), 1 * days_vest);
+        assertEq(VatAbstract(VAT).sin(VOW), originalSin + 1 * days_vest * RAY);
         hevm.warp(block.timestamp + 9 days);
         suckableVest.vest(id);
         assertEq(DSTokenAbstract(DAI).balanceOf(address(this)), 10 * days_vest);
+        assertEq(VatAbstract(VAT).sin(VOW), originalSin + 10 * days_vest * RAY);
         hevm.warp(block.timestamp + 365 days);
         suckableVest.vest(id);
         assertEq(DSTokenAbstract(DAI).balanceOf(address(this)), 100 * days_vest);
+        assertEq(VatAbstract(VAT).sin(VOW), originalSin + 100 * days_vest * RAY);
     }
 }

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -19,6 +19,11 @@ interface Token {
     function balanceOf(address) external returns (uint256);
 }
 
+interface VatLikeTest {
+    function wards(address) external view returns (uint256);
+    function sin(address) external view returns (uint256);
+}
+
 contract Manager {
     function yank(address dssvest, uint256 id) external {
         DssVest(dssvest).yank(id);
@@ -65,7 +70,7 @@ contract DssVestTest is DSTest {
             keccak256(abi.encode(address(suckableVest), uint256(0))),
             bytes32(uint256(1))
         );
-        assertEq(VatLike(VAT).wards(address(suckableVest)), 1);
+        assertEq(VatLikeTest(VAT).wards(address(suckableVest)), 1);
     }
 
     function testCost() public {
@@ -450,21 +455,21 @@ contract DssVestTest is DSTest {
     }
 
     function testSuckableVest() public {
-        uint256 originalSin = VatLike(VAT).sin(VOW);
+        uint256 originalSin = VatLikeTest(VAT).sin(VOW);
         uint256 id = suckableVest.init(address(this), 100 * days_vest, block.timestamp, 100 days, 0, address(0));
         assertTrue(suckableVest.valid(id));
         hevm.warp(block.timestamp + 1 days);
         suckableVest.vest(id);
-        assertEq(IERC20(DAI).balanceOf(address(this)), 1 * days_vest);
-        assertEq(VatLike(VAT).sin(VOW), originalSin + 1 * days_vest * RAY);
+        assertEq(Token(DAI).balanceOf(address(this)), 1 * days_vest);
+        assertEq(VatLikeTest(VAT).sin(VOW), originalSin + 1 * days_vest * RAY);
         hevm.warp(block.timestamp + 9 days);
         suckableVest.vest(id);
-        assertEq(IERC20(DAI).balanceOf(address(this)), 10 * days_vest);
-        assertEq(VatLike(VAT).sin(VOW), originalSin + 10 * days_vest * RAY);
+        assertEq(Token(DAI).balanceOf(address(this)), 10 * days_vest);
+        assertEq(VatLikeTest(VAT).sin(VOW), originalSin + 10 * days_vest * RAY);
         hevm.warp(block.timestamp + 365 days);
         suckableVest.vest(id);
-        assertEq(IERC20(DAI).balanceOf(address(this)), 100 * days_vest);
-        assertEq(VatLike(VAT).sin(VOW), originalSin + 100 * days_vest * RAY);
+        assertEq(Token(DAI).balanceOf(address(this)), 100 * days_vest);
+        assertEq(VatLikeTest(VAT).sin(VOW), originalSin + 100 * days_vest * RAY);
     }
 
     function testCap() public {

--- a/src/fuzz/DssVestEchidnaTest.sol
+++ b/src/fuzz/DssVestEchidnaTest.sol
@@ -7,7 +7,7 @@ import "../DssVest.sol";
 contract DssVestEchidnaTest {
 
     DssVestMintable internal vest;
-    DSTokenAbstract internal GEM;
+    IERC20 internal GEM;
 
     uint256 internal constant WAD = 10**18;
     uint256 internal immutable salt;

--- a/src/fuzz/DssVestEchidnaTest.sol
+++ b/src/fuzz/DssVestEchidnaTest.sol
@@ -6,14 +6,14 @@ import "../DssVest.sol";
 
 contract DssVestEchidnaTest {
 
-    DssVest internal vest;
-    IERC20 internal GEM;
+    DssVestMintable internal vest;
+    DSTokenAbstract internal GEM;
 
     uint256 internal constant WAD = 10**18;
     uint256 internal immutable salt;
 
     constructor() public {
-      vest = new DssVest(address(GEM));
+      vest = new DssVestMintable(address(GEM));
       vest.rely(address(this));
       salt = block.timestamp;
     }

--- a/src/fuzz/DssVestEchidnaTest.sol
+++ b/src/fuzz/DssVestEchidnaTest.sol
@@ -7,7 +7,7 @@ import "../DssVest.sol";
 contract DssVestEchidnaTest {
 
     DssVestMintable internal vest;
-    IERC20 internal GEM;
+    MintLike internal GEM;
 
     uint256 internal constant WAD = 10**18;
     uint256 internal immutable salt;


### PR DESCRIPTION
I'm using the style of the `vow` being a dependency which is called up upon payment to allow for `vow` updates in the future without having to update this contract. If you guys prefer to go with the usual `file("vow", vow);` style that's fine too, but I think this is cleaner for dependency management moving forward.