### PR TITLE
Add top variable to limit the maximum annual flow of tokens per vest

### DIFF
--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -226,7 +226,7 @@ contract DssVest {
     }
 
     function file(bytes32 what, uint256 data) external auth {
-        if      (what == "cap")         cap = data;     // The maximum amount of tokens that can be streamed per year per vest
+        if      (what == "cap")         cap = data;     // The maximum amount of tokens that can be streamed per-second per vest
         else revert("DssVest/file-unrecognized-param");
         emit File(what, data);
     }

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -69,12 +69,12 @@ contract DssVest {
     mapping (uint256 => Award) public awards;
     uint256 public ids;
 
-    uint256 public top; // Maximum annual tokens that can be disbursed [wad]
+    uint256 public cap; // Maximum per-second issuance token rate
 
     // This contract must be authorized to 'mint' on the token
-    constructor(address _gem, uint256 _top) public {
+    constructor(address _gem, uint256 _cap) public {
         gem = _gem;
-        top = _top;
+        cap = _cap;
         wards[msg.sender] = 1;
         emit Rely(msg.sender);
     }
@@ -112,7 +112,7 @@ contract DssVest {
         require(_bgn < add(block.timestamp, TWENTY_YEARS), "DssVest/bgn-too-far");
         require(_bgn > sub(block.timestamp, TWENTY_YEARS), "DssVest/bgn-too-long-ago");
         require(_tau > 0,                                  "DssVest/tau-zero");
-        require(_tot / _tau <= top / 365 days,             "DssVest/tot-too-high");
+        require(_tot / _tau <= cap,                        "DssVest/tot-too-high");
         require(_tau <= TWENTY_YEARS,                      "DssVest/tau-too-long");
         require(_clf <= _tau,                              "DssVest/clf-too-long");
         require(id < uint256(-1),                          "DssVest/id-overflow");
@@ -226,7 +226,7 @@ contract DssVest {
     }
 
     function file(bytes32 what, uint256 data) external auth {
-        if      (what == "top")         top = data;     // The maximum amount of tokens that can be streamed per year per vest
+        if      (what == "cap")         cap = data;     // The maximum amount of tokens that can be streamed per year per vest
         else revert("DssVest/file-unrecognized-param");
         emit File(what, data);
     }

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -438,9 +438,9 @@ contract DssVestTest is DSTest {
         uint256 id = vest.init(address(this), 500 * WAD, block.timestamp, 365 days, 0, address(0));
         assertEq(id, 1);
 
-        vest.file("cap", 4000 * WAD / 4 * 365 days);
+        vest.file("cap", (4000 * WAD) / (4 * 365 days));
 
-        id = vest.init(address(this), 1001 * WAD, block.timestamp, 365 days, 0, address(0));
+        id = vest.init(address(this), 1000 * WAD, block.timestamp, 365 days, 0, address(0));
         assertEq(id, 2);
     }
 

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -41,7 +41,7 @@ contract DssVestTest is DSTest {
 
     function setUp() public {
         hevm = Hevm(address(CHEAT_CODE));
-        vest = new DssVest(MKR_TOKEN, 500 * WAD);
+        vest = new DssVest(MKR_TOKEN, (2000 * WAD) / (4 * 365 days));
 
         // Set testing contract as a MKR Auth
         hevm.store(
@@ -433,18 +433,18 @@ contract DssVestTest is DSTest {
         vest.init(address(this), 100 * days_vest + 1, block.timestamp, 100 days, 101 days, address(0));
     }
 
-    function testTop() public {
+    function testCap() public {
         // Test init at top limit
         uint256 id = vest.init(address(this), 500 * WAD, block.timestamp, 365 days, 0, address(0));
         assertEq(id, 1);
 
-        vest.file("top", 1000 * WAD);
+        vest.file("cap", 4000 * WAD / 4 * 365 days);
 
-        id = vest.init(address(this), 1000 * WAD, block.timestamp, 365 days, 0, address(0));
+        id = vest.init(address(this), 1001 * WAD, block.timestamp, 365 days, 0, address(0));
         assertEq(id, 2);
     }
 
-    function testFailTop() public {
+    function testFailCap() public {
         // Test failure at 1 over limit
         vest.init(address(this), 501 * WAD, block.timestamp, 365 days, 0, address(0));
     }


### PR DESCRIPTION
Converts top to cap and uses a per-second rate instead of a max annual limit.

Opened a new PR because I'm not 100% sold on it.