### PR TITLE
Remove cap from constructor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all    :; DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=200 dapp --use solc:0.6.12 build
 clean  :; dapp clean
 test   :; ./test.sh $(match)
-deploy-kovan-suckable   :; make && dapp create DssVestSuckable 0xAaF64BFCC32d0F15873a02163e7E500671a4ffcD $(seth --to-uint256 3170979198376458650) # 100,000,000 Dai/yr
-deploy-kovan-mintable   :; make && dapp create DssVestMintable 0xAaF64BFCC32d0F15873a02163e7E500671a4ffcD $(seth --to-uint256 31709791983764)      # 1000 MKR/yr
-deploy-mainnet-suckable :; make && dapp create DssVestSuckable 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2 $(seth --to-uint256 3170979198376458650) # 100,000,000 Dai/yr
-deploy-mainnet-mintable :; make && dapp create DssVestMintable 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2 $(seth --to-uint256 31709791983764)      # 1000 MKR/yr
+deploy-kovan-suckable   :; make && dapp create DssVestSuckable 0xAaF64BFCC32d0F15873a02163e7E500671a4ffcD
+deploy-kovan-mintable   :; make && dapp create DssVestMintable 0xAaF64BFCC32d0F15873a02163e7E500671a4ffcD
+deploy-mainnet-suckable :; make && dapp create DssVestSuckable 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2
+deploy-mainnet-mintable :; make && dapp create DssVestMintable 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2

--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ $ dapp deploy-mainnet-suckable
 
 Pass the address of the vesting token to the constructor on deploy. This contract must be given authority to `mint()` tokens in the vesting contract.
 
+After deployment, governance must set the `cap` value using the `file` function.
+
 #### DssVestSuckable
 
 Pass the MCD [chainlog](https://github.com/makerdao/dss-chain-log) address to the constructor to set up the contract for scheduled Dai `suck`s. Note: this contract must be given authority to `suck()` Dai from the `vat`'s surplus buffer.
+
+After deployment, governance must set the `cap` value using the `file` function.
 
 ### Creating a vest
 

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -53,8 +53,10 @@ contract DssVestTest is DSTest {
 
     function setUp() public {
         hevm = Hevm(address(CHEAT_CODE));
-        vest = new DssVestMintable(MKR_TOKEN, (2000 * WAD) / (4 * 365 days));
-        suckableVest = new DssVestSuckable(CHAINLOG, (2000 * WAD) / (4 * 365 days));
+        vest = new DssVestMintable(MKR_TOKEN);
+        vest.file("cap", (2000 * WAD) / (4 * 365 days));
+        suckableVest = new DssVestSuckable(CHAINLOG);
+        suckableVest.file("cap", (2000 * WAD) / (4 * 365 days));
 
         // Set testing contract as a MKR Auth
         hevm.store(
@@ -74,7 +76,7 @@ contract DssVestTest is DSTest {
     }
 
     function testCost() public {
-        new DssVestMintable(MKR_TOKEN, 500 * WAD);
+        new DssVestMintable(MKR_TOKEN);
     }
 
     function testInit() public {

--- a/src/fuzz/DssVestEchidnaTest.sol
+++ b/src/fuzz/DssVestEchidnaTest.sol
@@ -13,8 +13,8 @@ contract DssVestEchidnaTest {
     uint256 internal immutable salt;
 
     constructor() public {
-      vest = new DssVestMintable(address(GEM), 500 * WAD);
-      vest.rely(address(this));
+      vest = new DssVestMintable(address(GEM));
+      vest.file("cap", 500 * WAD / 365 days);
       salt = block.timestamp;
     }
 


### PR DESCRIPTION
Removes `cap` from the constructor following pattern in `abacus` contracts.

This means that `file("cap", value)` must be called after the contract is deployed, but it should be done in the executive spell that authorizes the mint or suck functionality. That way the calculations are explicitly approved by governance and governance participants don't have to reverse any math that was done on the command line in order to validate the flow rate they're voting on.