### PR TITLE
Permissionless vest, with the option to restrict

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Returns the amount of tokens that have accrued from the beginning of the plan to
 
 Returns true if the plan id is valid and has not been claimed or yanked before the cliff.
 
+#### `restrict(uint256)`
+
+Allows governance or the owner to restrict vesting to the owner only.
+
+#### `unrestrict(uint256)`
+
+Allows governance or the owner to enable permissionless vesting.
+
 ### Revoking a vest
 
 #### `yank(_id)`

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -160,9 +160,7 @@ abstract contract DssVest {
     */
     function vest(uint256 _id) external lock {
         Award memory _award = awards[_id];
-        if (restricted[_id] == 1) {
-            require(_award.usr == msg.sender, "DssVest/only-user-can-claim");
-        }
+        require(restricted[_id] == 0 || _award.usr == msg.sender, "DssVest/only-user-can-claim");
         uint256 amt = unpaid(block.timestamp, _award.bgn, _award.clf, _award.fin, _award.tot, _award.rxd);
         pay(_award.usr, amt);
         awards[_id].rxd = toUint128(add(awards[_id].rxd, amt));

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -224,7 +224,7 @@ abstract contract DssVest {
         @dev Allows governance or the owner to restrict vesting to the owner only
         @param _id The id of the vesting contract
     */
-    function restrict(uint256 _id) public {
+    function restrict(uint256 _id) external {
         require(wards[msg.sender] == 1 || awards[_id].usr == msg.sender);
         restricted[_id] = 1;
     }
@@ -233,7 +233,7 @@ abstract contract DssVest {
         @dev Allows governance or the owner to enable permissionless vesting
         @param _id The id of the vesting contract
     */
-    function unrestrict(uint256 _id) public {
+    function unrestrict(uint256 _id) external {
         require(wards[msg.sender] == 1 || awards[_id].usr == msg.sender);
         restricted[_id] = 0;
     }

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -495,7 +495,7 @@ contract DssVestTest is DSTest {
         alice.vest(address(vest), id);
     }
 
-    function testRestrict() public {
+    function testRestrictions() public {
         User bob = new User();
         uint256 id = vest.init(address(bob), 100 * days_vest, block.timestamp, 100 days, 0 days, address(0));
 
@@ -504,17 +504,8 @@ contract DssVestTest is DSTest {
         bob.restrict(address(vest), id);
 
         assertEq(vest.restricted(id), 1);
-    }
 
-    function testUnrestrict() public {
-        User bob = new User();
-        uint256 id = vest.init(address(bob), 100 * days_vest, block.timestamp, 100 days, 0 days, address(0));
-
-        assertEq(vest.restricted(id), 0);
-
-        bob.restrict(address(vest), id);
-
-        assertEq(vest.restricted(id), 1);
+        bob.vest(address(vest), id);
 
         bob.unrestrict(address(vest), id);
 

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -30,6 +30,26 @@ contract Manager {
     }
 }
 
+contract ThirdPartyVest {
+    function vest(address dssvest, uint256 id) external {
+        DssVest(dssvest).vest(id);
+    }
+}
+
+contract User {
+    function vest(address dssvest, uint256 id) external {
+        DssVest(dssvest).vest(id);
+    }
+
+    function restrict(address dssvest, uint256 id) external {
+        DssVest(dssvest).restrict(id);
+    }
+
+    function unrestrict(address dssvest, uint256 id) external {
+        DssVest(dssvest).unrestrict(id);
+    }
+}
+
 contract DssVestTest is DSTest {
     Hevm hevm;
     DssVestMintable vest;
@@ -418,6 +438,96 @@ contract DssVestTest is DSTest {
         assertTrue(vest.valid(id2));
         manager.yank(address(vest), id2);
         assertTrue(!vest.valid(id2));
+    }
+
+    function testUnRestrictedVest() public {
+        ThirdPartyVest alice = new ThirdPartyVest();
+        uint256 id = vest.init(address(this), 100 * days_vest, block.timestamp, 100 days, 0 days, address(0));
+
+        hevm.warp(now + 10 days);
+
+        (address usr, uint48 bgn, uint48 clf, uint48 fin, uint128 amt, uint128 rxd, address mgr) = vest.awards(id);
+        assertEq(usr, address(this));
+        assertEq(uint256(bgn), now - 10 days);
+        assertEq(uint256(fin), now + 90 days);
+        assertEq(uint256(amt), 100 * days_vest);
+        assertEq(uint256(rxd), 0);
+        assertEq(Token(address(vest.gem())).balanceOf(address(this)), 0);
+
+        alice.vest(address(vest), id);
+
+        (usr, bgn, clf, fin, amt, rxd, mgr) = vest.awards(id);
+        assertEq(usr, address(this));
+        assertEq(uint256(bgn), now - 10 days);
+        assertEq(uint256(fin), now + 90 days);
+        assertEq(uint256(amt), 100 * days_vest);
+        assertEq(uint256(rxd), 10 * days_vest);
+        assertEq(Token(address(vest.gem())).balanceOf(address(this)), 10 * days_vest);
+
+        hevm.warp(now + 70 days);
+
+        alice.vest(address(vest), id);
+        (usr, bgn, clf, fin, amt, rxd, mgr) = vest.awards(id);
+        assertEq(usr, address(this));
+        assertEq(uint256(bgn), now - 80 days);
+        assertEq(uint256(fin), now + 20 days);
+        assertEq(uint256(amt), 100 * days_vest);
+        assertEq(uint256(rxd), 80 * days_vest);
+        assertEq(Token(address(vest.gem())).balanceOf(address(this)), 80 * days_vest);
+    }
+
+    function testFailRestrictedVest() public {
+        ThirdPartyVest alice = new ThirdPartyVest();
+        uint256 id = vest.init(address(this), 100 * days_vest, block.timestamp, 100 days, 0 days, address(0));
+
+        hevm.warp(now + 10 days);
+
+        (address usr, uint48 bgn,, uint48 fin, uint128 amt, uint128 rxd,) = vest.awards(id);
+        assertEq(usr, address(this));
+        assertEq(uint256(bgn), now - 10 days);
+        assertEq(uint256(fin), now + 90 days);
+        assertEq(uint256(amt), 100 * days_vest);
+        assertEq(uint256(rxd), 0);
+        assertEq(Token(address(vest.gem())).balanceOf(address(this)), 0);
+
+        vest.restrict(id);
+
+        alice.vest(address(vest), id);
+    }
+
+    function testRestrict() public {
+        User bob = new User();
+        uint256 id = vest.init(address(bob), 100 * days_vest, block.timestamp, 100 days, 0 days, address(0));
+
+        assertEq(vest.restricted(id), 0);
+
+        bob.restrict(address(vest), id);
+
+        assertEq(vest.restricted(id), 1);
+    }
+
+    function testUnrestrict() public {
+        User bob = new User();
+        uint256 id = vest.init(address(bob), 100 * days_vest, block.timestamp, 100 days, 0 days, address(0));
+
+        assertEq(vest.restricted(id), 0);
+
+        bob.restrict(address(vest), id);
+
+        assertEq(vest.restricted(id), 1);
+
+        bob.unrestrict(address(vest), id);
+
+        assertEq(vest.restricted(id), 0);
+
+        // also test auth ability
+        vest.restrict(id);
+
+        assertEq(vest.restricted(id), 1);
+
+        vest.unrestrict(id);
+
+        assertEq(vest.restricted(id), 0);
     }
 
     function testFailMgrYankUnauthed() public {


### PR DESCRIPTION
Changes the default vesting function to be permissionless, but adds the option to restrict or unrestrict a contract so that it can only be vested by the owner.