### PR TITLE
Add transferable token vest variant

### DIFF
--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -445,8 +445,6 @@ contract DssVestSuckable is DssVest {
  */
 contract DssVestTransferrable is DssVest {
 
-    uint256 internal constant RAY = 10**27;
-
     address   public immutable czar;
     TokenLike public immutable gem;
 
@@ -468,5 +466,4 @@ contract DssVestTransferrable is DssVest {
     function pay(address _guy, uint256 _amt) override internal {
         require(gem.transferFrom(czar, _guy, _amt));
     }
-
 }


### PR DESCRIPTION
Adds a variant of DssVest that allows a vesting contract to be enabled to stream a particular token type from a specific address.

For example, a CU multisig might want to set up streaming Dai contracts directly to contributors. This can be managed by deploying a new `DssVestTransferrable` and giving a token approval to the vesting contract from the sending contract.