### PR TITLE
Add `mutlock` to Echidna Tests

### DIFF
--- a/echidna/DssVestMintableEchidnaTest.sol
+++ b/echidna/DssVestMintableEchidnaTest.sol
@@ -7,6 +7,7 @@ import         {DSToken} from "./DSToken.sol";
 
 interface Hevm {
     function store(address, bytes32, bytes32) external;
+    function load(address, bytes32) external returns (bytes32);
 }
 
 struct Award {
@@ -132,7 +133,9 @@ contract DssVestMintableEchidnaTest {
             assert(mVest.res(id) == 0);
             _mutusr(id);
         } catch Error(string memory errmsg) {
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
+                uint256(mLocked) == 1                                    && cmpStr(errmsg, "DssVest/system-locked")        ||
                 mVest.wards(address(this)) == 0                          && cmpStr(errmsg, "DssVest/not-authorized")       ||
                 usr == address(0)                                        && cmpStr(errmsg, "DssVest/invalid-user")         ||
                 tot == 0                                                 && cmpStr(errmsg, "DssVest/no-vest-total-amount") ||
@@ -191,7 +194,9 @@ contract DssVestMintableEchidnaTest {
                 assert(gem.balanceOf(award.usr) == add(usrBalanceBefore, unpaidAmt));
             }
         } catch Error(string memory errmsg) {
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
+                uint256(mLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")       ||
                 award.usr == address(0)                                            && cmpStr(errmsg, "DssVest/invalid-award")       ||
                 award.res != 0 && award.usr != address(this)                       && cmpStr(errmsg, "DssVest/only-user-can-claim") ||
                 accruedAmt - award.rxd > accruedAmt                                && cmpStr(errmsg, "DssVest/sub-underflow")       ||
@@ -238,7 +243,9 @@ contract DssVestMintableEchidnaTest {
                 assert(gem.balanceOf(award.usr) == add(usrBalanceBefore, amt));
             }
         } catch Error(string memory errmsg) {
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
+                uint256(mLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")       ||
                 award.usr == address(0)                                            && cmpStr(errmsg, "DssVest/invalid-award")       ||
                 award.res != 0 && award.usr != address(this)                       && cmpStr(errmsg, "DssVest/only-user-can-claim") ||
                 accruedAmt - award.rxd > accruedAmt                                && cmpStr(errmsg, "DssVest/sub-underflow")       ||
@@ -260,7 +267,9 @@ contract DssVestMintableEchidnaTest {
         try mVest.restrict(id) {
             assert(mVest.res(id) == 1);
         } catch Error(string memory errmsg) {
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
+                uint256(mLocked) == 1           && cmpStr(errmsg, "DssVest/system-locked") ||
                 mVest.usr(id) == address(0)     && cmpStr(errmsg, "DssVest/invalid-award") ||
                 mVest.wards(address(this)) == 0 &&
                 mVest.usr(id) != address(this)  && cmpStr(errmsg, "DssVest/not-authorized")
@@ -275,7 +284,9 @@ contract DssVestMintableEchidnaTest {
         try mVest.unrestrict(id) {
             assert(mVest.res(id) == 0);
         } catch Error(string memory errmsg) {
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
+               uint256(mLocked) == 1           && cmpStr(errmsg, "DssVest/system-locked") ||
                mVest.usr(id) == address(0)     && cmpStr(errmsg, "DssVest/invalid-award") ||
                mVest.wards(address(this)) == 0 &&
                mVest.usr(id) != address(this)  && cmpStr(errmsg, "DssVest/not-authorized")
@@ -308,7 +319,9 @@ contract DssVestMintableEchidnaTest {
                 }
             }
         } catch Error(string memory errmsg) {
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
+                uint256(mLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")    ||
                 mVest.wards(address(this)) == 0 && mgr != address(this)            && cmpStr(errmsg, "DssVest/not-authorized")   ||
                 usr == address(0)                                                  && cmpStr(errmsg, "DssVest/invalid-award")    ||
                 uint128(end) != end                                                && cmpStr(errmsg, "DssVest/uint128-overflow") ||
@@ -330,7 +343,9 @@ contract DssVestMintableEchidnaTest {
             assert(mVest.usr(id) == dst);
             _mutusr(id);
         } catch Error(string memory errmsg) {
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
+                uint256(mLocked) == 1          && cmpStr(errmsg, "DssVest/system-locked")       ||
                 mVest.usr(id) != address(this) && cmpStr(errmsg, "DssVest/only-user-can-move")  ||
                 dst == address(0)              && cmpStr(errmsg, "DssVest/zero-address-invalid")
             );
@@ -341,6 +356,10 @@ contract DssVestMintableEchidnaTest {
 
     // --- Time-Based Fuzz Mutations ---
 
+    function mutlock() public clock(1 hours) {
+        // Set DssVestMintable locked slot n. 4 to override 0 with 1
+        hevm.store(address(mVest), bytes32(uint256(4)), bytes32(uint256(1)));
+    }
     function mutauth() public clock(1 hours) {
         uint256 wards = mVest.wards(address(this)) == 1 ? 0 : 1;
         // Set DssVestMintable wards slot n. 0 to override address(this) wards


### PR DESCRIPTION
Introduce `mutlock` in Echidna Tests following https://github.com/makerdao/dss-vest/pull/43/commits/da4348ce353b064cc1c9c314d6b43a6ae8c34e67