### PR TITLE
Add `vat.live` check to DssVestSuckable `pay`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ After deployment, governance must set the `cap` value using the `file` function.
 
 Pass the MCD [chainlog](https://github.com/makerdao/dss-chain-log) address to the constructor to set up the contract for scheduled Dai `suck`s. Note: this contract must be given authority to `suck()` Dai from the `vat`'s surplus buffer.
 
+A `vat.live` check is introduced to disable `suck()` in the event of Emergency Shutdown (aka Global Settlement).
+
 After deployment, governance must set the `cap` value using the `file` function.
 
 #### DssVestTransferrable

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ After deployment, governance must set the `cap` value using the `file` function.
 
 Pass the MCD [chainlog](https://github.com/makerdao/dss-chain-log) address to the constructor to set up the contract for scheduled Dai `suck`s. Note: this contract must be given authority to `suck()` Dai from the `vat`'s surplus buffer.
 
-A `vat.live` check is introduced to disable `suck()` in the event of Emergency Shutdown (aka Global Settlement).
+A `vat.live` check is introduced to disable `vest()` in the event of Emergency Shutdown (aka Global Settlement).
 
 After deployment, governance must set the `cap` value using the `file` function.
 

--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ Allows governance to schedule a point in the future to end the vest. Used for pl
 
 ### Install Echidna
 
-- Install Echidna v1.7.3
+- Install Echidna v2.0.0
   ```
-  $ nix-env -i -f https://github.com/crytic/echidna/archive/v1.7.3.tar.gz
+  $ nix-env -i -f https://github.com/crytic/echidna/archive/v2.0.0.tar.gz
   ```
-- Install Echidna v1.7.3 via [echidnup](https://github.com/naszam/echidnup#installing)
+- Install Echidna v2.0.0 via [echidnup](https://github.com/naszam/echidnup#installing)
   ```
-  $ echidnup v1.7.3
+  $ echidnup v2.0.0
   ```
 
 ### Local Dependencies

--- a/certora/DssVestSuckable.spec
+++ b/certora/DssVestSuckable.spec
@@ -32,6 +32,7 @@ methods {
     vat.sin(address) returns (uint256) envfree
     vat.debt() returns (uint256) envfree
     vat.vice() returns (uint256) envfree
+    vat.live() returns (uint256) envfree
     dai.wards(address) returns (uint256) envfree
     dai.totalSupply() returns (uint256) envfree
     dai.balanceOf(address) returns (uint256) envfree
@@ -421,6 +422,7 @@ rule vest_revert(uint256 _id) {
     uint256 usrBalance = dai.balanceOf(usr);
     uint256 supply = dai.totalSupply();
     uint256 locked = lockedGhost();
+    uint256 vatLive = vat.live();
     address vow = chainlog.getAddress(e, 0x4d43445f564f5700000000000000000000000000000000000000000000000000);
     uint256 daiJoinLive = daiJoin.live();
     uint256 wardVat = vat.wards(currentContract);
@@ -458,19 +460,20 @@ rule vest_revert(uint256 _id) {
     bool revert6  = e.block.timestamp >= clf && e.block.timestamp >= bgn && e.block.timestamp < fin && fin == bgn;
     bool revert7  = e.block.timestamp >= clf && accruedAmt < rxd;
     bool revert8  = rxd + unpaidAmt > max_uint128;
-    bool revert9  = vow == 0;
-    bool revert10 = unpaidAmtRad > max_uint256;
-    bool revert11 = wardVat != 1;
-    bool revert12 = sinVow + unpaidAmtRad > max_uint256;
-    bool revert13 = vatDaiVest + unpaidAmtRad > max_uint256;
-    bool revert14 = vice + unpaidAmtRad > max_uint256;
-    bool revert15 = debt + unpaidAmtRad > max_uint256;
-    bool revert16 = daiJoinLive != 1;
-    bool revert17 = currentContract != daiJoin && canVestDaiJoin != 1;
-    bool revert18 = vatDaiDaiJoin + unpaidAmtRad > max_uint256;
-    bool revert19 = wardDai != 1;
-    bool revert20 = usrBalance + unpaidAmt > max_uint256;
-    bool revert21 = supply + unpaidAmt > max_uint256;
+    bool revert9  = vatLive != 1;
+    bool revert10 = vow == 0;
+    bool revert11 = unpaidAmtRad > max_uint256;
+    bool revert12 = wardVat != 1;
+    bool revert13 = sinVow + unpaidAmtRad > max_uint256;
+    bool revert14 = vatDaiVest + unpaidAmtRad > max_uint256;
+    bool revert15 = vice + unpaidAmtRad > max_uint256;
+    bool revert16 = debt + unpaidAmtRad > max_uint256;
+    bool revert17 = daiJoinLive != 1;
+    bool revert18 = currentContract != daiJoin && canVestDaiJoin != 1;
+    bool revert19 = vatDaiDaiJoin + unpaidAmtRad > max_uint256;
+    bool revert20 = wardDai != 1;
+    bool revert21 = usrBalance + unpaidAmt > max_uint256;
+    bool revert22 = supply + unpaidAmt > max_uint256;
 
     assert(revert1  => lastReverted, "Sending ETH did not revert");
     assert(revert2  => lastReverted, "Locked did not revert");
@@ -480,19 +483,20 @@ rule vest_revert(uint256 _id) {
     assert(revert6  => lastReverted, "Division by zero did not revert");
     assert(revert7  => lastReverted, "Underflow accruedAmt - rxd did not revert");
     assert(revert8  => lastReverted, "Overflow rxd + unpaidAmt or toUint128 cast did not revert");
-    assert(revert9  => lastReverted, "Zero vow address did not revert");
-    assert(revert10 => lastReverted, "Overflow RAY * unpaidAmt did not revert");
-    assert(revert11 => lastReverted, "Vat lack of auth did not revert");
-    assert(revert12 => lastReverted, "Overflow sin + rad did not revert");
-    assert(revert13 => lastReverted, "Overflow dai + rad did not revert");
-    assert(revert14 => lastReverted, "Overflow vice + rad did not revert");
-    assert(revert15 => lastReverted, "Overflow debt + rad did not revert");
-    assert(revert16 => lastReverted, "Not live daiJoin did not revert");
-    assert(revert17 => lastReverted, "The function wish did not revert");
-    assert(revert18 => lastReverted, "Overflow dst + rad did not revert");
-    assert(revert19 => lastReverted, "Lack of dai auth on daiJoin did not revert");
-    assert(revert20 => lastReverted, "Overflow usr balance did not revert");
-    assert(revert21 => lastReverted, "Overflow totalSupply did not revert");
+    assert(revert9  => lastReverted, "Not live Vat did not revert");
+    assert(revert10 => lastReverted, "Zero vow address did not revert");
+    assert(revert11 => lastReverted, "Overflow RAY * unpaidAmt did not revert");
+    assert(revert12 => lastReverted, "Vat lack of auth did not revert");
+    assert(revert13 => lastReverted, "Overflow sin + rad did not revert");
+    assert(revert14 => lastReverted, "Overflow dai + rad did not revert");
+    assert(revert15 => lastReverted, "Overflow vice + rad did not revert");
+    assert(revert16 => lastReverted, "Overflow debt + rad did not revert");
+    assert(revert17 => lastReverted, "Not live daiJoin did not revert");
+    assert(revert18 => lastReverted, "The function wish did not revert");
+    assert(revert19 => lastReverted, "Overflow dst + rad did not revert");
+    assert(revert20 => lastReverted, "Lack of dai auth on daiJoin did not revert");
+    assert(revert21 => lastReverted, "Overflow usr balance did not revert");
+    assert(revert22 => lastReverted, "Overflow totalSupply did not revert");
 
     assert(lastReverted =>
             revert1  || revert2  || revert3  ||
@@ -501,7 +505,8 @@ rule vest_revert(uint256 _id) {
             revert10 || revert11 || revert12 ||
             revert13 || revert14 || revert15 ||
             revert16 || revert17 || revert18 ||
-            revert19 || revert20 || revert21, "Revert rules are not covering all the cases");
+            revert19 || revert20 || revert21 ||
+            revert22, "Revert rules are not covering all the cases");
 }
 
 // Verify that awards behave correctly on vest with arbitrary max amt
@@ -578,6 +583,7 @@ rule vest_amt_revert(uint256 _id, uint256 _maxAmt) {
     uint256 usrBalance = dai.balanceOf(usr);
     uint256 supply = dai.totalSupply();
     uint256 locked = lockedGhost();
+    uint256 vatLive = vat.live();
     address vow = chainlog.getAddress(e, 0x4d43445f564f5700000000000000000000000000000000000000000000000000);
     uint256 daiJoinLive = daiJoin.live();
     uint256 wardVat = vat.wards(currentContract);
@@ -617,19 +623,20 @@ rule vest_amt_revert(uint256 _id, uint256 _maxAmt) {
     bool revert6  = e.block.timestamp >= clf && e.block.timestamp >= bgn && e.block.timestamp < fin && fin == bgn;
     bool revert7  = e.block.timestamp >= clf && accruedAmt < rxd;
     bool revert8  = rxd + amt > max_uint128;
-    bool revert9  = vow == 0;
-    bool revert10 = amtRad > max_uint256;
-    bool revert11 = wardVat != 1;
-    bool revert12 = sinVow + amtRad > max_uint256;
-    bool revert13 = vatDaiVest + amtRad > max_uint256;
-    bool revert14 = vice + amtRad > max_uint256;
-    bool revert15 = debt + amtRad > max_uint256;
-    bool revert16 = daiJoinLive != 1;
-    bool revert17 = currentContract != daiJoin && canVestDaiJoin != 1;
-    bool revert18 = vatDaiDaiJoin + amtRad > max_uint256;
-    bool revert19 = wardDai != 1;
-    bool revert20 = usrBalance + amt > max_uint256;
-    bool revert21 = supply + amt > max_uint256;
+    bool revert9  = vatLive != 1;
+    bool revert10 = vow == 0;
+    bool revert11 = amtRad > max_uint256;
+    bool revert12 = wardVat != 1;
+    bool revert13 = sinVow + amtRad > max_uint256;
+    bool revert14 = vatDaiVest + amtRad > max_uint256;
+    bool revert15 = vice + amtRad > max_uint256;
+    bool revert16 = debt + amtRad > max_uint256;
+    bool revert17 = daiJoinLive != 1;
+    bool revert18 = currentContract != daiJoin && canVestDaiJoin != 1;
+    bool revert19 = vatDaiDaiJoin + amtRad > max_uint256;
+    bool revert20 = wardDai != 1;
+    bool revert21 = usrBalance + amt > max_uint256;
+    bool revert22 = supply + amt > max_uint256;
 
     assert(revert1  => lastReverted, "Sending ETH did not revert");
     assert(revert2  => lastReverted, "Locked did not revert");
@@ -639,19 +646,20 @@ rule vest_amt_revert(uint256 _id, uint256 _maxAmt) {
     assert(revert6  => lastReverted, "Division by zero did not revert");
     assert(revert7  => lastReverted, "Underflow accruedAmt - rxd did not revert");
     assert(revert8  => lastReverted, "Overflow rxd + amt or toUint128 cast did not revert");
-    assert(revert9  => lastReverted, "Zero vow address did not revert");
-    assert(revert10 => lastReverted, "Overflow RAY * amt did not revert");
-    assert(revert11 => lastReverted, "Lack of vat auth on suckable did not revert");
-    assert(revert12 => lastReverted, "Overflow sin + rad did not revert");
-    assert(revert13 => lastReverted, "Overflow dai + rad did not revert");
-    assert(revert14 => lastReverted, "Overflow vice + rad did not revert");
-    assert(revert15 => lastReverted, "Overflow debt + rad did not revert");
-    assert(revert16 => lastReverted, "Not live daiJoin did not revert");
-    assert(revert17 => lastReverted, "The function wish did not revert");
-    assert(revert18 => lastReverted, "Overflow dst + rad did not revert");
-    assert(revert19 => lastReverted, "Lack of dai auth on daiJoin did not revert");
-    assert(revert20 => lastReverted, "Overflow usr balance did not revert");
-    assert(revert21 => lastReverted, "Overflow totalSupply did not revert");
+    assert(revert9  => lastReverted, "Not live Vat did not revert");
+    assert(revert10 => lastReverted, "Zero vow address did not revert");
+    assert(revert11 => lastReverted, "Overflow RAY * amt did not revert");
+    assert(revert12 => lastReverted, "Lack of vat auth on suckable did not revert");
+    assert(revert13 => lastReverted, "Overflow sin + rad did not revert");
+    assert(revert14 => lastReverted, "Overflow dai + rad did not revert");
+    assert(revert15 => lastReverted, "Overflow vice + rad did not revert");
+    assert(revert16 => lastReverted, "Overflow debt + rad did not revert");
+    assert(revert17 => lastReverted, "Not live daiJoin did not revert");
+    assert(revert18 => lastReverted, "The function wish did not revert");
+    assert(revert19 => lastReverted, "Overflow dst + rad did not revert");
+    assert(revert20 => lastReverted, "Lack of dai auth on daiJoin did not revert");
+    assert(revert21 => lastReverted, "Overflow usr balance did not revert");
+    assert(revert22 => lastReverted, "Overflow totalSupply did not revert");
 
     assert(lastReverted =>
             revert1  || revert2  || revert3  ||
@@ -660,7 +668,8 @@ rule vest_amt_revert(uint256 _id, uint256 _maxAmt) {
             revert10 || revert11 || revert12 ||
             revert13 || revert14 || revert15 ||
             revert16 || revert17 || revert18 ||
-            revert19 || revert20 || revert21, "Revert rules are not covering all the cases");
+            revert19 || revert20 || revert21 ||
+            revert22, "Revert rules are not covering all the cases");
 }
 
 // Verify that amt behaves correctly on accrued

--- a/echidna.config.yml
+++ b/echidna.config.yml
@@ -1,7 +1,7 @@
 #format can be "text" or "json" for different output (human or machine readable)
 #format: "text"
-#checkAsserts checks assertions
-checkAsserts: true
+#select the mode to test, which can be property, assertion, overflow, exploration, optimization
+testMode: "assertion"
 #testLimit is the number of test sequences to run
 testLimit: 1000000
 #seqLen defines how many transactions are in a test sequence

--- a/echidna/DssVestMintableEchidnaTest.sol
+++ b/echidna/DssVestMintableEchidnaTest.sol
@@ -50,10 +50,6 @@ contract DssVestMintableEchidnaTest {
         z = x + y;
         assert(z >= x); // check if there is an addition overflow
     }
-    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        z = x * y;
-        assert(y == 0 || z / y == x);
-    }
     function toUint8(uint256 x) internal pure returns (uint8 z) {
         z = uint8(x);
         assert(z == x);

--- a/echidna/DssVestMintableEchidnaTest.sol
+++ b/echidna/DssVestMintableEchidnaTest.sol
@@ -2,23 +2,12 @@
 
 pragma solidity 0.6.12;
 
-import {DssVestMintable} from "../src/DssVest.sol";
+import {DssVest, DssVestMintable} from "../src/DssVest.sol";
 import         {DSToken} from "./DSToken.sol";
 
 interface Hevm {
     function store(address, bytes32, bytes32) external;
     function load(address, bytes32) external returns (bytes32);
-}
-
-struct Award {
-    address usr;   // Vesting recipient
-    uint48  bgn;   // Start of vesting period  [timestamp]
-    uint48  clf;   // The cliff date           [timestamp]
-    uint48  fin;   // End of vesting period    [timestamp]
-    address mgr;   // A manager address that can yank
-    uint8   res;   // Restricted
-    uint128 tot;   // Total reward amount
-    uint128 rxd;   // Amount of vest claimed
 }
 
 contract DssVestMintableEchidnaTest {
@@ -158,7 +147,7 @@ contract DssVestMintableEchidnaTest {
 
     function vest(uint256 id) public {
         id = mVest.ids() == 0 ? id : id % mVest.ids();
-        Award memory award = Award({
+        DssVest.Award memory award = DssVest.Award({
             usr: mVest.usr(id),
             bgn: toUint48(mVest.bgn(id)),
             clf: toUint48(mVest.clf(id)),
@@ -211,7 +200,7 @@ contract DssVestMintableEchidnaTest {
 
     function vest_amt(uint256 id, uint256 maxAmt) public {
         id = mVest.ids() == 0 ? id : id % mVest.ids();
-        Award memory award = Award({
+        DssVest.Award memory award = DssVest.Award({
             usr: mVest.usr(id),
             bgn: toUint48(mVest.bgn(id)),
             clf: toUint48(mVest.clf(id)),

--- a/echidna/DssVestMintableEchidnaTest.sol
+++ b/echidna/DssVestMintableEchidnaTest.sol
@@ -357,8 +357,12 @@ contract DssVestMintableEchidnaTest {
     // --- Time-Based Fuzz Mutations ---
 
     function mutlock() public clock(1 hours) {
-        // Set DssVestMintable locked slot n. 4 to override 0 with 1
-        hevm.store(address(mVest), bytes32(uint256(4)), bytes32(uint256(1)));
+        bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));          // Load memory slot 0x4
+        uint256 locked = uint256(mLocked) == 0 ? 1 : 0;
+        // Set DssVestMintable locked slot n. 4 to override 0 with 1 and vice versa
+        hevm.store(address(mVest), bytes32(uint256(4)), bytes32(uint256(locked)));
+        mLocked = hevm.load(address(mVest), bytes32(uint256(4)));
+        assert(uint256(mLocked) == locked);
     }
     function mutauth() public clock(1 hours) {
         uint256 wards = mVest.wards(address(this)) == 1 ? 0 : 1;

--- a/echidna/DssVestMintableEchidnaTest.sol
+++ b/echidna/DssVestMintableEchidnaTest.sol
@@ -57,13 +57,9 @@ contract DssVestMintableEchidnaTest {
     }
 
     // --- Math ---
-    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
+    function _add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x + y;
         assert(z >= x); // check if there is an addition overflow
-    }
-    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        z = x - y;
-        assert(z <= x); // check if there is a subtraction overflow
     }
     function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x * y;
@@ -120,13 +116,13 @@ contract DssVestMintableEchidnaTest {
     function create(address usr, uint256 tot, uint256 bgn, uint256 tau, uint256 eta, address mgr) public {
         uint256 prevId = mVest.ids();
         try mVest.create(usr, tot, bgn, tau, eta, mgr) returns (uint256 id) {
-            assert(mVest.ids() == add(prevId, 1));
+            assert(mVest.ids() == _add(prevId, 1));
             assert(mVest.ids() == id);
             assert(mVest.valid(id));
             assert(mVest.usr(id) == usr);
             assert(mVest.bgn(id) == toUint48(bgn));
-            assert(mVest.clf(id) == toUint48(add(bgn, eta)));
-            assert(mVest.fin(id) == toUint48(add(bgn, tau)));
+            assert(mVest.clf(id) == toUint48(_add(bgn, eta)));
+            assert(mVest.fin(id) == toUint48(_add(bgn, tau)));
             assert(mVest.tot(id) == toUint128(tot));
             assert(mVest.rxd(id) == 0);
             assert(mVest.mgr(id) == mgr);
@@ -188,10 +184,10 @@ contract DssVestMintableEchidnaTest {
                     assert(mVest.rxd(id) == award.tot);
                 }
                 else {
-                    assert(mVest.rxd(id) == toUint128(add(award.rxd, unpaidAmt)));
+                    assert(mVest.rxd(id) == toUint128(_add(award.rxd, unpaidAmt)));
                 }
-                assert(gem.totalSupply() == add(supplyBefore, unpaidAmt));
-                assert(gem.balanceOf(award.usr) == add(usrBalanceBefore, unpaidAmt));
+                assert(gem.totalSupply() == _add(supplyBefore, unpaidAmt));
+                assert(gem.balanceOf(award.usr) == _add(usrBalanceBefore, unpaidAmt));
             }
         } catch Error(string memory errmsg) {
             bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
@@ -238,9 +234,9 @@ contract DssVestMintableEchidnaTest {
                 assert(gem.balanceOf(award.usr) == usrBalanceBefore);
             }
             else {
-                assert(mVest.rxd(id) == toUint128(add(award.rxd, amt)));
-                assert(gem.totalSupply() == add(supplyBefore, amt));
-                assert(gem.balanceOf(award.usr) == add(usrBalanceBefore, amt));
+                assert(mVest.rxd(id) == toUint128(_add(award.rxd, amt)));
+                assert(gem.totalSupply() == _add(supplyBefore, amt));
+                assert(gem.balanceOf(award.usr) == _add(usrBalanceBefore, amt));
             }
         } catch Error(string memory errmsg) {
             bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
@@ -315,7 +311,7 @@ contract DssVestMintableEchidnaTest {
                     assert(mVest.clf(id) == end);
                     assert(mVest.tot(id) == 0);
                 } else {
-                    assert(mVest.tot(id) == toUint128(add(unpaidAmt, rxd)));
+                    assert(mVest.tot(id) == toUint128(_add(unpaidAmt, rxd)));
                 }
             }
         } catch Error(string memory errmsg) {

--- a/echidna/DssVestMintableEchidnaTest.sol
+++ b/echidna/DssVestMintableEchidnaTest.sol
@@ -337,7 +337,7 @@ contract DssVestMintableEchidnaTest {
 
     // --- Time-Based Fuzz Mutations ---
 
-    function mutlock() public clock(1 hours) {
+    function mutlock() private clock(1 hours) {
         bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));          // Load memory slot 0x4
         uint256 locked = uint256(mLocked) == 0 ? 1 : 0;
         // Set DssVestMintable locked slot n. 4 to override 0 with 1 and vice versa
@@ -345,13 +345,13 @@ contract DssVestMintableEchidnaTest {
         mLocked = hevm.load(address(mVest), bytes32(uint256(4)));
         assert(uint256(mLocked) == locked);
     }
-    function mutauth() public clock(1 hours) {
+    function mutauth() private clock(1 hours) {
         uint256 wards = mVest.wards(address(this)) == 1 ? 0 : 1;
         // Set DssVestMintable wards slot n. 0 to override address(this) wards
         hevm.store(address(mVest), keccak256(abi.encode(address(this), uint256(0))), bytes32(uint256(wards)));
         assert(mVest.wards(address(this)) == wards);
     }
-    function mutusr(uint256 id) public clock(1 days) {
+    function mutusr(uint256 id) private clock(1 days) {
         id = mVest.ids() == 0 ? 0 : id % mVest.ids();
         if (id == 0) return;
         _mutusr(id);
@@ -362,7 +362,7 @@ contract DssVestMintableEchidnaTest {
         hevm.store(address(mVest), keccak256(abi.encode(uint256(id), uint256(1))), bytesToBytes32(abi.encodePacked(uint48(mVest.clf(id)), uint48(mVest.bgn(id)), usr)));
         assert(mVest.usr(id) == usr);
     }
-    function mutcap(uint256 bump) public clock(90 days) {
+    function mutcap(uint256 bump) private clock(90 days) {
         bump %= MAX;
         if (bump == 0) return;
         uint256 data = bump > MIN ? bump * WAD / YEAR : MIN * WAD / YEAR;

--- a/echidna/DssVestSuckableEchidnaTest.sol
+++ b/echidna/DssVestSuckableEchidnaTest.sol
@@ -387,7 +387,7 @@ contract DssVestSuckableEchidnaTest {
 
     // --- Time-Based Fuzz Mutations ---
 
-    function mutlock() public clock(1 hours) {
+    function mutlock() private clock(1 hours) {
         bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));          // Load memory slot 0x4
         uint256 locked = uint256(sLocked) == 0 ? 1 : 0;
         // Set DssVestSuckable locked slot n. 4 to override 0 with 1 and vice versa
@@ -395,19 +395,19 @@ contract DssVestSuckableEchidnaTest {
         sLocked = hevm.load(address(sVest), bytes32(uint256(4)));
         assert(uint256(sLocked) == locked);
     }
-    function mutauth() public clock(1 hours) {
+    function mutauth() private clock(1 hours) {
         uint256 wards = sVest.wards(address(this)) == 1 ? 0 : 1;
         // Set DssVestSuckable wards slot n. 0 to override address(this) wards
         hevm.store(address(sVest), keccak256(abi.encode(address(this), uint256(0))), bytes32(uint256(wards)));
         assert(sVest.wards(address(this)) == wards);
     }
-    function mutlive() public clock(1 hours) {
+    function mutlive() private clock(1 hours) {
         uint256 live = vat.live() == 1 ? 0 : 1;
         // Set Vat live slot n. 10 to override 1 with 0 and vice versa
         hevm.store(address(vat), bytes32(uint256(10)), bytes32(uint256(live)));
         assert(vat.live() == live);
     }
-    function mutusr(uint256 id) public clock(1 days) {
+    function mutusr(uint256 id) private clock(1 days) {
         id = sVest.ids() == 0 ? 0 : id % sVest.ids();
         if (id == 0) return;
         _mutusr(id);
@@ -418,7 +418,7 @@ contract DssVestSuckableEchidnaTest {
         hevm.store(address(sVest), keccak256(abi.encode(uint256(id), uint256(1))), bytesToBytes32(abi.encodePacked(uint48(sVest.clf(id)), uint48(sVest.bgn(id)), usr)));
         assert(sVest.usr(id) == usr);
     }
-    function mutcap(uint256 bump) public clock(90 days) {
+    function mutcap(uint256 bump) private clock(90 days) {
         bump %= MAX;
         if (bump == 0) return;
         uint256 data = bump > MIN ? bump * WAD / TIME : MIN * WAD / TIME;

--- a/echidna/DssVestSuckableEchidnaTest.sol
+++ b/echidna/DssVestSuckableEchidnaTest.sol
@@ -403,8 +403,12 @@ contract DssVestSuckableEchidnaTest {
     // --- Time-Based Fuzz Mutations ---
 
     function mutlock() public clock(1 hours) {
-        // Set DssVestSuckable locked slot n. 4 to override 0 with 1
-        hevm.store(address(sVest), bytes32(uint256(4)), bytes32(uint256(1)));
+        bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));          // Load memory slot 0x4
+        uint256 locked = uint256(sLocked) == 0 ? 1 : 0;
+        // Set DssVestSuckable locked slot n. 4 to override 0 with 1 and vice versa
+        hevm.store(address(sVest), bytes32(uint256(4)), bytes32(uint256(locked)));
+        sLocked = hevm.load(address(sVest), bytes32(uint256(4)));
+        assert(uint256(sLocked) == locked);
     }
     function mutauth() public clock(1 hours) {
         uint256 wards = sVest.wards(address(this)) == 1 ? 0 : 1;

--- a/echidna/DssVestSuckableEchidnaTest.sol
+++ b/echidna/DssVestSuckableEchidnaTest.sol
@@ -75,13 +75,9 @@ contract DssVestSuckableEchidnaTest {
     }
 
     // --- Math ---
-    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
+    function _add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x + y;
         assert(z >= x); // check if there is an addition overflow
-    }
-    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        z = x - y;
-        assert(z <= x); // check if there is a subtraction overflow
     }
     function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x * y;
@@ -138,13 +134,13 @@ contract DssVestSuckableEchidnaTest {
     function create(address usr, uint256 tot, uint256 bgn, uint256 tau, uint256 eta, address mgr) public {
         uint256 prevId = sVest.ids();
         try sVest.create(usr, tot, bgn, tau, eta, mgr) returns (uint256 id) {
-            assert(sVest.ids() == add(prevId, 1));
+            assert(sVest.ids() == _add(prevId, 1));
             assert(sVest.ids() == id);
             assert(sVest.valid(id));
             assert(sVest.usr(id) == usr);
             assert(sVest.bgn(id) == toUint48(bgn));
-            assert(sVest.clf(id) == toUint48(add(bgn, eta)));
-            assert(sVest.fin(id) == toUint48(add(bgn, tau)));
+            assert(sVest.clf(id) == toUint48(_add(bgn, eta)));
+            assert(sVest.fin(id) == toUint48(_add(bgn, tau)));
             assert(sVest.tot(id) == toUint128(tot));
             assert(sVest.rxd(id) == 0);
             assert(sVest.mgr(id) == mgr);
@@ -208,11 +204,11 @@ contract DssVestSuckableEchidnaTest {
                     assert(sVest.rxd(id) == award.tot);
                 }
                 else {
-                    assert(sVest.rxd(id) == toUint128(add(award.rxd, unpaidAmt)));
+                    assert(sVest.rxd(id) == toUint128(_add(award.rxd, unpaidAmt)));
                 }
-                assert(vat.sin(vow) == add(sinBefore, mul(unpaidAmt, RAY)));
-                assert(dai.totalSupply() == add(supplyBefore, unpaidAmt));
-                assert(dai.balanceOf(award.usr) == add(usrBalanceBefore, unpaidAmt));
+                assert(vat.sin(vow) == _add(sinBefore, mul(unpaidAmt, RAY)));
+                assert(dai.totalSupply() == _add(supplyBefore, unpaidAmt));
+                assert(dai.balanceOf(award.usr) == _add(usrBalanceBefore, unpaidAmt));
             }
         } catch Error(string memory errmsg) {
             bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));      // Load memory slot 0x4
@@ -272,10 +268,10 @@ contract DssVestSuckableEchidnaTest {
                 assert(dai.balanceOf(award.usr) == usrBalanceBefore);
             }
             else {
-                assert(sVest.rxd(id) == toUint128(add(award.rxd, amt)));
-                assert(vat.sin(vow) == add(sinBefore, mul(amt, RAY)));
-                assert(dai.totalSupply() == add(supplyBefore, amt));
-                assert(dai.balanceOf(award.usr) == add(usrBalanceBefore, amt));
+                assert(sVest.rxd(id) == toUint128(_add(award.rxd, amt)));
+                assert(vat.sin(vow) == _add(sinBefore, mul(amt, RAY)));
+                assert(dai.totalSupply() == _add(supplyBefore, amt));
+                assert(dai.balanceOf(award.usr) == _add(usrBalanceBefore, amt));
             }
         } catch Error(string memory errmsg) {
             bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));      // Load memory slot 0x4
@@ -361,7 +357,7 @@ contract DssVestSuckableEchidnaTest {
                     assert(sVest.clf(id) == end);
                     assert(sVest.tot(id) == 0);
                 } else {
-                    assert(sVest.tot(id) == toUint128(add(unpaidAmt, rxd)));
+                    assert(sVest.tot(id) == toUint128(_add(unpaidAmt, rxd)));
                 }
             }
         } catch Error(string memory errmsg) {

--- a/echidna/DssVestSuckableEchidnaTest.sol
+++ b/echidna/DssVestSuckableEchidnaTest.sol
@@ -217,17 +217,18 @@ contract DssVestSuckableEchidnaTest {
         } catch Error(string memory errmsg) {
             bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
-                uint256(sLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")       ||
-                award.usr == address(0)                                            && cmpStr(errmsg, "DssVest/invalid-award")       ||
-                award.res != 0 && award.usr != address(this)                       && cmpStr(errmsg, "DssVest/only-user-can-claim") ||
-                accruedAmt - award.rxd > accruedAmt                                && cmpStr(errmsg, "DssVest/sub-underflow")       ||
-                award.fin - award.bgn > award.fin                                  && cmpStr(errmsg, "DssVest/sub-underflow")       ||
-                timeDelta > block.timestamp                                        && cmpStr(errmsg, "DssVest/sub-underflow")       ||
-                timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot && cmpStr(errmsg, "DssVest/mul-overflow")        ||
-                award.rxd + unpaidAmt < award.rxd                                  && cmpStr(errmsg, "DssVest/add-overflow")        ||
-                uint128(award.rxd + unpaidAmt) != (award.rxd + unpaidAmt)          && cmpStr(errmsg, "DssVest/uint128-overflow")    ||
-                unpaidAmt * RAY / RAY != unpaidAmt                                 && cmpStr(errmsg, "DssVest/mul-overflow")        ||
-                daiJoin.live() == 0                                                && cmpStr(errmsg, "DaiJoin/not-live")            ||
+                uint256(sLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")        ||
+                award.usr == address(0)                                            && cmpStr(errmsg, "DssVest/invalid-award")        ||
+                award.res != 0 && award.usr != address(this)                       && cmpStr(errmsg, "DssVest/only-user-can-claim")  ||
+                accruedAmt - award.rxd > accruedAmt                                && cmpStr(errmsg, "DssVest/sub-underflow")        ||
+                award.fin - award.bgn > award.fin                                  && cmpStr(errmsg, "DssVest/sub-underflow")        ||
+                timeDelta > block.timestamp                                        && cmpStr(errmsg, "DssVest/sub-underflow")        ||
+                timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot && cmpStr(errmsg, "DssVest/mul-overflow")         ||
+                award.rxd + unpaidAmt < award.rxd                                  && cmpStr(errmsg, "DssVest/add-overflow")         ||
+                uint128(award.rxd + unpaidAmt) != (award.rxd + unpaidAmt)          && cmpStr(errmsg, "DssVest/uint128-overflow")     ||
+                vat.live() == 0                                                    && cmpStr(errmsg, "DssVestSuckable/vat-not-live") ||
+                unpaidAmt * RAY / RAY != unpaidAmt                                 && cmpStr(errmsg, "DssVest/mul-overflow")         ||
+                daiJoin.live() == 0                                                && cmpStr(errmsg, "DaiJoin/not-live")             ||
                 vat.can(address(sVest), address(daiJoin)) != 1                     && cmpStr(errmsg, "Vat/not-allowed")
             );
         } catch {
@@ -279,17 +280,18 @@ contract DssVestSuckableEchidnaTest {
         } catch Error(string memory errmsg) {
             bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
-                uint256(sLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")       ||
-                award.usr == address(0)                                            && cmpStr(errmsg, "DssVest/invalid-award")       ||
-                award.res != 0 && award.usr != address(this)                       && cmpStr(errmsg, "DssVest/only-user-can-claim") ||
-                accruedAmt - award.rxd > accruedAmt                                && cmpStr(errmsg, "DssVest/sub-underflow")       ||
-                award.fin - award.bgn > award.fin                                  && cmpStr(errmsg, "DssVest/sub-underflow")       ||
-                timeDelta > block.timestamp                                        && cmpStr(errmsg, "DssVest/sub-underflow")       ||
-                timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot && cmpStr(errmsg, "DssVest/mul-overflow")        ||
-                award.rxd + amt < award.rxd                                        && cmpStr(errmsg, "DssVest/add-overflow")        ||
-                uint128(award.rxd + amt) != (award.rxd + amt)                      && cmpStr(errmsg, "DssVest/uint128-overflow")    ||
-                amt * RAY / RAY != amt                                             && cmpStr(errmsg, "DssVest/mul-overflow")        ||
-                daiJoin.live() == 0                                                && cmpStr(errmsg, "DaiJoin/not-live")            ||
+                uint256(sLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")        ||
+                award.usr == address(0)                                            && cmpStr(errmsg, "DssVest/invalid-award")        ||
+                award.res != 0 && award.usr != address(this)                       && cmpStr(errmsg, "DssVest/only-user-can-claim")  ||
+                accruedAmt - award.rxd > accruedAmt                                && cmpStr(errmsg, "DssVest/sub-underflow")        ||
+                award.fin - award.bgn > award.fin                                  && cmpStr(errmsg, "DssVest/sub-underflow")        ||
+                timeDelta > block.timestamp                                        && cmpStr(errmsg, "DssVest/sub-underflow")        ||
+                timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot && cmpStr(errmsg, "DssVest/mul-overflow")         ||
+                award.rxd + amt < award.rxd                                        && cmpStr(errmsg, "DssVest/add-overflow")         ||
+                uint128(award.rxd + amt) != (award.rxd + amt)                      && cmpStr(errmsg, "DssVest/uint128-overflow")     ||
+                vat.live() == 0                                                    && cmpStr(errmsg, "DssVestSuckable/vat-not-live") ||
+                amt * RAY / RAY != amt                                             && cmpStr(errmsg, "DssVest/mul-overflow")         ||
+                daiJoin.live() == 0                                                && cmpStr(errmsg, "DaiJoin/not-live")             ||
                 vat.can(address(sVest), address(daiJoin)) != 1                     && cmpStr(errmsg, "Vat/not-allowed")
             );
         } catch {
@@ -409,6 +411,12 @@ contract DssVestSuckableEchidnaTest {
         // Set DssVestSuckable wards slot n. 0 to override address(this) wards
         hevm.store(address(sVest), keccak256(abi.encode(address(this), uint256(0))), bytes32(uint256(wards)));
         assert(sVest.wards(address(this)) == wards);
+    }
+    function mutlive() public clock(1 hours) {
+        uint256 live = vat.live() == 1 ? 0 : 1;
+        // Set Vat live slot n. 10 to override 1 with 0 and vice versa
+        hevm.store(address(vat), bytes32(uint256(10)), bytes32(uint256(live)));
+        assert(vat.live() == live);
     }
     function mutusr(uint256 id) public clock(1 days) {
         id = sVest.ids() == 0 ? 0 : id % sVest.ids();

--- a/echidna/DssVestSuckableEchidnaTest.sol
+++ b/echidna/DssVestSuckableEchidnaTest.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.6.12;
 
-import {DssVestSuckable} from "../src/DssVest.sol";
+import {DssVest, DssVestSuckable} from "../src/DssVest.sol";
 import        {ChainLog} from "./ChainLog.sol";
 import             {Vat} from "./Vat.sol";
 import         {DaiJoin} from "./DaiJoin.sol";
@@ -11,17 +11,6 @@ import             {Dai} from "./Dai.sol";
 interface Hevm {
     function store(address, bytes32, bytes32) external;
     function load(address, bytes32) external returns (bytes32);
-}
-
-struct Award {
-    address usr;   // Vesting recipient
-    uint48  bgn;   // Start of vesting period  [timestamp]
-    uint48  clf;   // The cliff date           [timestamp]
-    uint48  fin;   // End of vesting period    [timestamp]
-    address mgr;   // A manager address that can yank
-    uint8   res;   // Restricted
-    uint128 tot;   // Total reward amount
-    uint128 rxd;   // Amount of vest claimed
 }
 
 contract DssVestSuckableEchidnaTest {
@@ -176,7 +165,7 @@ contract DssVestSuckableEchidnaTest {
 
     function vest(uint256 id) public {
         id = sVest.ids() == 0 ? id : id % sVest.ids();
-        Award memory award = Award({
+        DssVest.Award memory award = DssVest.Award({
             usr: sVest.usr(id),
             bgn: toUint48(sVest.bgn(id)),
             clf: toUint48(sVest.clf(id)),
@@ -243,7 +232,7 @@ contract DssVestSuckableEchidnaTest {
 
     function vest_amt(uint256 id, uint256 maxAmt) public {
         id = sVest.ids() == 0 ? id : id % sVest.ids();
-        Award memory award = Award({
+        DssVest.Award memory award = DssVest.Award({
             usr: sVest.usr(id),
             bgn: toUint48(sVest.bgn(id)),
             clf: toUint48(sVest.clf(id)),

--- a/echidna/DssVestSuckableEchidnaTest.sol
+++ b/echidna/DssVestSuckableEchidnaTest.sol
@@ -68,7 +68,7 @@ contract DssVestSuckableEchidnaTest {
         z = x + y;
         assert(z >= x); // check if there is an addition overflow
     }
-    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+    function _mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x * y;
         assert(y == 0 || z / y == x);
     }
@@ -195,7 +195,7 @@ contract DssVestSuckableEchidnaTest {
                 else {
                     assert(sVest.rxd(id) == toUint128(_add(award.rxd, unpaidAmt)));
                 }
-                assert(vat.sin(vow) == _add(sinBefore, mul(unpaidAmt, RAY)));
+                assert(vat.sin(vow) == _add(sinBefore, _mul(unpaidAmt, RAY)));
                 assert(dai.totalSupply() == _add(supplyBefore, unpaidAmt));
                 assert(dai.balanceOf(award.usr) == _add(usrBalanceBefore, unpaidAmt));
             }
@@ -258,7 +258,7 @@ contract DssVestSuckableEchidnaTest {
             }
             else {
                 assert(sVest.rxd(id) == toUint128(_add(award.rxd, amt)));
-                assert(vat.sin(vow) == _add(sinBefore, mul(amt, RAY)));
+                assert(vat.sin(vow) == _add(sinBefore, _mul(amt, RAY)));
                 assert(dai.totalSupply() == _add(supplyBefore, amt));
                 assert(dai.balanceOf(award.usr) == _add(usrBalanceBefore, amt));
             }

--- a/echidna/DssVestTransferrableEchidnaTest.sol
+++ b/echidna/DssVestTransferrableEchidnaTest.sol
@@ -62,13 +62,9 @@ contract DssVestTransferrableEchidnaTest {
         z = x + y;
         assert(z >= x); // check if there is an addition overflow
     }
-    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
+    function _sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x - y;
         assert(z <= x); // check if there is a subtraction overflow
-    }
-    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        z = x * y;
-        assert(y == 0 || z / y == x);
     }
     function toUint8(uint256 x) internal pure returns (uint8 z) {
         z = uint8(x);
@@ -192,7 +188,7 @@ contract DssVestTransferrableEchidnaTest {
                 else {
                     assert(tVest.rxd(id) == toUint128(_add(award.rxd, unpaidAmt)));
                 }
-                assert(gem.balanceOf(address(multisig)) == sub(msigBalanceBefore, unpaidAmt));
+                assert(gem.balanceOf(address(multisig)) == _sub(msigBalanceBefore, unpaidAmt));
                 assert(gem.balanceOf(award.usr) == _add(usrBalanceBefore, unpaidAmt));
             }
             assert(gem.totalSupply() == supplyBefore);
@@ -249,7 +245,7 @@ contract DssVestTransferrableEchidnaTest {
             }
             else {
                 assert(tVest.rxd(id) == toUint128(_add(award.rxd, amt)));
-                assert(gem.balanceOf(address(multisig)) == sub(msigBalanceBefore, amt));
+                assert(gem.balanceOf(address(multisig)) == _sub(msigBalanceBefore, amt));
                 assert(gem.balanceOf(award.usr) == _add(usrBalanceBefore, amt));
             }
             assert(gem.totalSupply() == supplyBefore);

--- a/echidna/DssVestTransferrableEchidnaTest.sol
+++ b/echidna/DssVestTransferrableEchidnaTest.sol
@@ -369,7 +369,7 @@ contract DssVestTransferrableEchidnaTest {
 
     // --- Time-Based Fuzz Mutations ---
 
-    function mutlock() public clock(1 hours) {
+    function mutlock() private clock(1 hours) {
         bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));          // Load memory slot 0x4
         uint256 locked = uint256(tLocked) == 0 ? 1 : 0;
         // Set DssVestTransferrable locked slot n. 4 to override 0 with 1 and vice versa
@@ -377,13 +377,13 @@ contract DssVestTransferrableEchidnaTest {
         tLocked = hevm.load(address(tVest), bytes32(uint256(4)));
         assert(uint256(tLocked) == locked);
     }
-    function mutauth() public clock(1 hours) {
+    function mutauth() private clock(1 hours) {
         uint256 wards = tVest.wards(address(this)) == 1 ? 0 : 1;
         // Set DssVestTransferrable wards slot n. 0 to override address(this) wards
         hevm.store(address(tVest), keccak256(abi.encode(address(this), uint256(0))), bytes32(uint256(wards)));
         assert(tVest.wards(address(this)) == wards);
     }
-    function mutusr(uint256 id) public clock(1 days) {
+    function mutusr(uint256 id) private clock(1 days) {
         id = tVest.ids() == 0 ? 0 : id % tVest.ids();
         if (id == 0) return;
         _mutusr(id);
@@ -394,7 +394,7 @@ contract DssVestTransferrableEchidnaTest {
         hevm.store(address(tVest), keccak256(abi.encode(uint256(id), uint256(1))), bytesToBytes32(abi.encodePacked(uint48(tVest.clf(id)), uint48(tVest.bgn(id)), usr)));
         assert(tVest.usr(id) == usr);
     }
-    function mutcap(uint256 bump) public clock(90 days) {
+    function mutcap(uint256 bump) private clock(90 days) {
         bump %= MAX;
         if (bump == 0) return;
         uint256 data = bump > MIN ? bump * WAD / TIME : MIN * WAD / TIME;

--- a/echidna/DssVestTransferrableEchidnaTest.sol
+++ b/echidna/DssVestTransferrableEchidnaTest.sol
@@ -204,11 +204,10 @@ contract DssVestTransferrableEchidnaTest {
                 timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot    && cmpStr(errmsg, "DssVest/mul-overflow")                ||
                 award.rxd + unpaidAmt < award.rxd                                     && cmpStr(errmsg, "DssVest/add-overflow")                ||
                 uint128(award.rxd + unpaidAmt) != (award.rxd + unpaidAmt)             && cmpStr(errmsg, "DssVest/uint128-overflow")            ||
-                gem.balanceOf(address(multisig)) < unpaidAmt                          && cmpStr(errmsg, "gem/insufficient-balance")
-                                                                                      && cmpStr(errmsg, "DssVestTransferable/failed-transfer") ||
+                gem.balanceOf(address(multisig)) < unpaidAmt                          && cmpStr(errmsg, "gem/insufficient-balance")            ||
                 gem.allowance(address(multisig), address(tVest)) != type(uint256).max &&
-                gem.allowance(address(multisig), address(tVest)) < unpaidAmt          && cmpStr(errmsg, "gem/insufficient-allowance")
-                                                                                      && cmpStr(errmsg, "DssVestTransferable/failed-transfer")
+                gem.allowance(address(multisig), address(tVest)) < unpaidAmt          && cmpStr(errmsg, "gem/insufficient-allowance")          ||
+                                                                                         cmpStr(errmsg, "DssVestTransferable/failed-transfer")
             );
         } catch {
             assert(
@@ -263,11 +262,10 @@ contract DssVestTransferrableEchidnaTest {
                 timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot    && cmpStr(errmsg, "DssVest/mul-overflow")                ||
                 award.rxd + amt < award.rxd                                           && cmpStr(errmsg, "DssVest/add-overflow")                ||
                 uint128(award.rxd + amt) != (award.rxd + amt)                         && cmpStr(errmsg, "DssVest/uint128-overflow")            ||
-                gem.balanceOf(address(multisig)) < amt                                && cmpStr(errmsg, "gem/insufficient-balance")
-                                                                                      && cmpStr(errmsg, "DssVestTransferable/failed-transfer") ||
+                gem.balanceOf(address(multisig)) < amt                                && cmpStr(errmsg, "gem/insufficient-balance")            ||
                 gem.allowance(address(multisig), address(tVest)) != type(uint256).max &&
-                gem.allowance(address(multisig), address(tVest)) < amt                && cmpStr(errmsg, "gem/insufficient-allowance")
-                                                                                      && cmpStr(errmsg, "DssVestTransferable/failed-transfer")
+                gem.allowance(address(multisig), address(tVest)) < amt                && cmpStr(errmsg, "gem/insufficient-allowance")          ||
+                                                                                         cmpStr(errmsg, "DssVestTransferable/failed-transfer")
 
             );
         } catch {

--- a/echidna/DssVestTransferrableEchidnaTest.sol
+++ b/echidna/DssVestTransferrableEchidnaTest.sol
@@ -385,8 +385,12 @@ contract DssVestTransferrableEchidnaTest {
     // --- Time-Based Fuzz Mutations ---
 
     function mutlock() public clock(1 hours) {
-        // Set DssVestTransferrable locked slot n. 4 to override 0 with 1
-        hevm.store(address(tVest), bytes32(uint256(4)), bytes32(uint256(1)));
+        bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));          // Load memory slot 0x4
+        uint256 locked = uint256(tLocked) == 0 ? 1 : 0;
+        // Set DssVestTransferrable locked slot n. 4 to override 0 with 1 and vice versa
+        hevm.store(address(tVest), bytes32(uint256(4)), bytes32(uint256(locked)));
+        tLocked = hevm.load(address(tVest), bytes32(uint256(4)));
+        assert(uint256(tLocked) == locked);
     }
     function mutauth() public clock(1 hours) {
         uint256 wards = tVest.wards(address(this)) == 1 ? 0 : 1;

--- a/echidna/DssVestTransferrableEchidnaTest.sol
+++ b/echidna/DssVestTransferrableEchidnaTest.sol
@@ -206,8 +206,7 @@ contract DssVestTransferrableEchidnaTest {
                 uint128(award.rxd + unpaidAmt) != (award.rxd + unpaidAmt)             && cmpStr(errmsg, "DssVest/uint128-overflow")            ||
                 gem.balanceOf(address(multisig)) < unpaidAmt                          && cmpStr(errmsg, "gem/insufficient-balance")            ||
                 gem.allowance(address(multisig), address(tVest)) != type(uint256).max &&
-                gem.allowance(address(multisig), address(tVest)) < unpaidAmt          && cmpStr(errmsg, "gem/insufficient-allowance")          ||
-                                                                                         cmpStr(errmsg, "DssVestTransferable/failed-transfer")
+                gem.allowance(address(multisig), address(tVest)) < unpaidAmt          && cmpStr(errmsg, "gem/insufficient-allowance")
             );
         } catch {
             assert(
@@ -264,9 +263,7 @@ contract DssVestTransferrableEchidnaTest {
                 uint128(award.rxd + amt) != (award.rxd + amt)                         && cmpStr(errmsg, "DssVest/uint128-overflow")            ||
                 gem.balanceOf(address(multisig)) < amt                                && cmpStr(errmsg, "gem/insufficient-balance")            ||
                 gem.allowance(address(multisig), address(tVest)) != type(uint256).max &&
-                gem.allowance(address(multisig), address(tVest)) < amt                && cmpStr(errmsg, "gem/insufficient-allowance")          ||
-                                                                                         cmpStr(errmsg, "DssVestTransferable/failed-transfer")
-
+                gem.allowance(address(multisig), address(tVest)) < amt                && cmpStr(errmsg, "gem/insufficient-allowance")
             );
         } catch {
             assert(

--- a/echidna/DssVestTransferrableEchidnaTest.sol
+++ b/echidna/DssVestTransferrableEchidnaTest.sol
@@ -69,7 +69,7 @@ contract DssVestTransferrableEchidnaTest {
     }
 
     // --- Math ---
-    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
+    function _add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x + y;
         assert(z >= x); // check if there is an addition overflow
     }
@@ -132,13 +132,13 @@ contract DssVestTransferrableEchidnaTest {
     function create(address usr, uint256 tot, uint256 bgn, uint256 tau, uint256 eta, address mgr) public {
         uint256 prevId = tVest.ids();
         try tVest.create(usr, tot, bgn, tau, eta, mgr) returns (uint256 id) {
-            assert(tVest.ids() == add(prevId, 1));
+            assert(tVest.ids() == _add(prevId, 1));
             assert(tVest.ids() == id);
             assert(tVest.valid(id));
             assert(tVest.usr(id) == usr);
             assert(tVest.bgn(id) == toUint48(bgn));
-            assert(tVest.clf(id) == toUint48(add(bgn, eta)));
-            assert(tVest.fin(id) == toUint48(add(bgn, tau)));
+            assert(tVest.clf(id) == toUint48(_add(bgn, eta)));
+            assert(tVest.fin(id) == toUint48(_add(bgn, tau)));
             assert(tVest.tot(id) == toUint128(tot));
             assert(tVest.rxd(id) == 0);
             assert(tVest.mgr(id) == mgr);
@@ -201,10 +201,10 @@ contract DssVestTransferrableEchidnaTest {
                     assert(tVest.rxd(id) == award.tot);
                 }
                 else {
-                    assert(tVest.rxd(id) == toUint128(add(award.rxd, unpaidAmt)));
+                    assert(tVest.rxd(id) == toUint128(_add(award.rxd, unpaidAmt)));
                 }
                 assert(gem.balanceOf(address(multisig)) == sub(msigBalanceBefore, unpaidAmt));
-                assert(gem.balanceOf(award.usr) == add(usrBalanceBefore, unpaidAmt));
+                assert(gem.balanceOf(award.usr) == _add(usrBalanceBefore, unpaidAmt));
             }
             assert(gem.totalSupply() == supplyBefore);
         } catch Error(string memory errmsg) {
@@ -259,9 +259,9 @@ contract DssVestTransferrableEchidnaTest {
                 assert(gem.balanceOf(award.usr) == usrBalanceBefore);
             }
             else {
-                assert(tVest.rxd(id) == toUint128(add(award.rxd, amt)));
+                assert(tVest.rxd(id) == toUint128(_add(award.rxd, amt)));
                 assert(gem.balanceOf(address(multisig)) == sub(msigBalanceBefore, amt));
-                assert(gem.balanceOf(award.usr) == add(usrBalanceBefore, amt));
+                assert(gem.balanceOf(award.usr) == _add(usrBalanceBefore, amt));
             }
             assert(gem.totalSupply() == supplyBefore);
         } catch Error(string memory errmsg) {
@@ -343,7 +343,7 @@ contract DssVestTransferrableEchidnaTest {
                     assert(tVest.clf(id) == end);
                     assert(tVest.tot(id) == 0);
                 } else {
-                    assert(tVest.tot(id) == toUint128(add(unpaidAmt, rxd)));
+                    assert(tVest.tot(id) == toUint128(_add(unpaidAmt, rxd)));
                 }
             }
         } catch Error(string memory errmsg) {

--- a/echidna/DssVestTransferrableEchidnaTest.sol
+++ b/echidna/DssVestTransferrableEchidnaTest.sol
@@ -195,16 +195,16 @@ contract DssVestTransferrableEchidnaTest {
         } catch Error(string memory errmsg) {
             bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
-                uint256(tLocked) == 1                                                 && cmpStr(errmsg, "DssVest/system-locked")               ||
-                award.usr == address(0)                                               && cmpStr(errmsg, "DssVest/invalid-award")               ||
-                award.res !=0 && award.usr != address(this)                           && cmpStr(errmsg, "DssVest/only-user-can-claim")         ||
-                accruedAmt - award.rxd > accruedAmt                                   && cmpStr(errmsg, "DssVest/sub-underflow")               ||
-                award.fin - award.bgn > award.fin                                     && cmpStr(errmsg, "DssVest/sub-underflow")               ||
-                timeDelta > block.timestamp                                           && cmpStr(errmsg, "DssVest/sub-underflow")               ||
-                timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot    && cmpStr(errmsg, "DssVest/mul-overflow")                ||
-                award.rxd + unpaidAmt < award.rxd                                     && cmpStr(errmsg, "DssVest/add-overflow")                ||
-                uint128(award.rxd + unpaidAmt) != (award.rxd + unpaidAmt)             && cmpStr(errmsg, "DssVest/uint128-overflow")            ||
-                gem.balanceOf(address(multisig)) < unpaidAmt                          && cmpStr(errmsg, "gem/insufficient-balance")            ||
+                uint256(tLocked) == 1                                                 && cmpStr(errmsg, "DssVest/system-locked")       ||
+                award.usr == address(0)                                               && cmpStr(errmsg, "DssVest/invalid-award")       ||
+                award.res !=0 && award.usr != address(this)                           && cmpStr(errmsg, "DssVest/only-user-can-claim") ||
+                accruedAmt - award.rxd > accruedAmt                                   && cmpStr(errmsg, "DssVest/sub-underflow")       ||
+                award.fin - award.bgn > award.fin                                     && cmpStr(errmsg, "DssVest/sub-underflow")       ||
+                timeDelta > block.timestamp                                           && cmpStr(errmsg, "DssVest/sub-underflow")       ||
+                timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot    && cmpStr(errmsg, "DssVest/mul-overflow")        ||
+                award.rxd + unpaidAmt < award.rxd                                     && cmpStr(errmsg, "DssVest/add-overflow")        ||
+                uint128(award.rxd + unpaidAmt) != (award.rxd + unpaidAmt)             && cmpStr(errmsg, "DssVest/uint128-overflow")    ||
+                gem.balanceOf(address(multisig)) < unpaidAmt                          && cmpStr(errmsg, "gem/insufficient-balance")    ||
                 gem.allowance(address(multisig), address(tVest)) != type(uint256).max &&
                 gem.allowance(address(multisig), address(tVest)) < unpaidAmt          && cmpStr(errmsg, "gem/insufficient-allowance")
             );
@@ -252,16 +252,16 @@ contract DssVestTransferrableEchidnaTest {
         } catch Error(string memory errmsg) {
             bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
-                uint256(tLocked) == 1                                                 && cmpStr(errmsg, "DssVest/system-locked")               ||
-                award.usr == address(0)                                               && cmpStr(errmsg, "DssVest/invalid-award")               ||
-                award.res != 0 && award.usr != address(this)                          && cmpStr(errmsg, "DssVest/only-user-can-claim")         ||
-                accruedAmt - award.rxd > accruedAmt                                   && cmpStr(errmsg, "DssVest/sub-underflow")               ||
-                award.fin - award.bgn > award.fin                                     && cmpStr(errmsg, "DssVest/sub-underflow")               ||
-                timeDelta > block.timestamp                                           && cmpStr(errmsg, "DssVest/sub-underflow")               ||
-                timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot    && cmpStr(errmsg, "DssVest/mul-overflow")                ||
-                award.rxd + amt < award.rxd                                           && cmpStr(errmsg, "DssVest/add-overflow")                ||
-                uint128(award.rxd + amt) != (award.rxd + amt)                         && cmpStr(errmsg, "DssVest/uint128-overflow")            ||
-                gem.balanceOf(address(multisig)) < amt                                && cmpStr(errmsg, "gem/insufficient-balance")            ||
+                uint256(tLocked) == 1                                                 && cmpStr(errmsg, "DssVest/system-locked")       ||
+                award.usr == address(0)                                               && cmpStr(errmsg, "DssVest/invalid-award")       ||
+                award.res != 0 && award.usr != address(this)                          && cmpStr(errmsg, "DssVest/only-user-can-claim") ||
+                accruedAmt - award.rxd > accruedAmt                                   && cmpStr(errmsg, "DssVest/sub-underflow")       ||
+                award.fin - award.bgn > award.fin                                     && cmpStr(errmsg, "DssVest/sub-underflow")       ||
+                timeDelta > block.timestamp                                           && cmpStr(errmsg, "DssVest/sub-underflow")       ||
+                timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot    && cmpStr(errmsg, "DssVest/mul-overflow")        ||
+                award.rxd + amt < award.rxd                                           && cmpStr(errmsg, "DssVest/add-overflow")        ||
+                uint128(award.rxd + amt) != (award.rxd + amt)                         && cmpStr(errmsg, "DssVest/uint128-overflow")    ||
+                gem.balanceOf(address(multisig)) < amt                                && cmpStr(errmsg, "gem/insufficient-balance")    ||
                 gem.allowance(address(multisig), address(tVest)) != type(uint256).max &&
                 gem.allowance(address(multisig), address(tVest)) < amt                && cmpStr(errmsg, "gem/insufficient-allowance")
             );

--- a/echidna/DssVestTransferrableEchidnaTest.sol
+++ b/echidna/DssVestTransferrableEchidnaTest.sol
@@ -195,18 +195,20 @@ contract DssVestTransferrableEchidnaTest {
         } catch Error(string memory errmsg) {
             bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
-                uint256(tLocked) == 1                                                 && cmpStr(errmsg, "DssVest/system-locked")       ||
-                award.usr == address(0)                                               && cmpStr(errmsg, "DssVest/invalid-award")       ||
-                award.res !=0 && award.usr != address(this)                           && cmpStr(errmsg, "DssVest/only-user-can-claim") ||
-                accruedAmt - award.rxd > accruedAmt                                   && cmpStr(errmsg, "DssVest/sub-underflow")       ||
-                award.fin - award.bgn > award.fin                                     && cmpStr(errmsg, "DssVest/sub-underflow")       ||
-                timeDelta > block.timestamp                                           && cmpStr(errmsg, "DssVest/sub-underflow")       ||
-                timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot    && cmpStr(errmsg, "DssVest/mul-overflow")        ||
-                award.rxd + unpaidAmt < award.rxd                                     && cmpStr(errmsg, "DssVest/add-overflow")        ||
-                uint128(award.rxd + unpaidAmt) != (award.rxd + unpaidAmt)             && cmpStr(errmsg, "DssVest/uint128-overflow")    ||
-                gem.balanceOf(address(multisig)) < unpaidAmt                          && cmpStr(errmsg, "gem/insufficient-balance")    ||
+                uint256(tLocked) == 1                                                 && cmpStr(errmsg, "DssVest/system-locked")               ||
+                award.usr == address(0)                                               && cmpStr(errmsg, "DssVest/invalid-award")               ||
+                award.res !=0 && award.usr != address(this)                           && cmpStr(errmsg, "DssVest/only-user-can-claim")         ||
+                accruedAmt - award.rxd > accruedAmt                                   && cmpStr(errmsg, "DssVest/sub-underflow")               ||
+                award.fin - award.bgn > award.fin                                     && cmpStr(errmsg, "DssVest/sub-underflow")               ||
+                timeDelta > block.timestamp                                           && cmpStr(errmsg, "DssVest/sub-underflow")               ||
+                timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot    && cmpStr(errmsg, "DssVest/mul-overflow")                ||
+                award.rxd + unpaidAmt < award.rxd                                     && cmpStr(errmsg, "DssVest/add-overflow")                ||
+                uint128(award.rxd + unpaidAmt) != (award.rxd + unpaidAmt)             && cmpStr(errmsg, "DssVest/uint128-overflow")            ||
+                gem.balanceOf(address(multisig)) < unpaidAmt                          && cmpStr(errmsg, "gem/insufficient-balance")
+                                                                                      && cmpStr(errmsg, "DssVestTransferable/failed-transfer") ||
                 gem.allowance(address(multisig), address(tVest)) != type(uint256).max &&
                 gem.allowance(address(multisig), address(tVest)) < unpaidAmt          && cmpStr(errmsg, "gem/insufficient-allowance")
+                                                                                      && cmpStr(errmsg, "DssVestTransferable/failed-transfer")
             );
         } catch {
             assert(
@@ -252,18 +254,21 @@ contract DssVestTransferrableEchidnaTest {
         } catch Error(string memory errmsg) {
             bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));      // Load memory slot 0x4
             assert(
-                uint256(tLocked) == 1                                                 && cmpStr(errmsg, "DssVest/system-locked")       ||
-                award.usr == address(0)                                               && cmpStr(errmsg, "DssVest/invalid-award")       ||
-                award.res != 0 && award.usr != address(this)                          && cmpStr(errmsg, "DssVest/only-user-can-claim") ||
-                accruedAmt - award.rxd > accruedAmt                                   && cmpStr(errmsg, "DssVest/sub-underflow")       ||
-                award.fin - award.bgn > award.fin                                     && cmpStr(errmsg, "DssVest/sub-underflow")       ||
-                timeDelta > block.timestamp                                           && cmpStr(errmsg, "DssVest/sub-underflow")       ||
-                timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot    && cmpStr(errmsg, "DssVest/mul-overflow")        ||
-                award.rxd + amt < award.rxd                                           && cmpStr(errmsg, "DssVest/add-overflow")        ||
-                uint128(award.rxd + amt) != (award.rxd + amt)                         && cmpStr(errmsg, "DssVest/uint128-overflow")    ||
-                gem.balanceOf(address(multisig)) < amt                                && cmpStr(errmsg, "gem/insufficient-balance")    ||
+                uint256(tLocked) == 1                                                 && cmpStr(errmsg, "DssVest/system-locked")               ||
+                award.usr == address(0)                                               && cmpStr(errmsg, "DssVest/invalid-award")               ||
+                award.res != 0 && award.usr != address(this)                          && cmpStr(errmsg, "DssVest/only-user-can-claim")         ||
+                accruedAmt - award.rxd > accruedAmt                                   && cmpStr(errmsg, "DssVest/sub-underflow")               ||
+                award.fin - award.bgn > award.fin                                     && cmpStr(errmsg, "DssVest/sub-underflow")               ||
+                timeDelta > block.timestamp                                           && cmpStr(errmsg, "DssVest/sub-underflow")               ||
+                timeDelta != 0 && (award.tot * timeDelta) / timeDelta != award.tot    && cmpStr(errmsg, "DssVest/mul-overflow")                ||
+                award.rxd + amt < award.rxd                                           && cmpStr(errmsg, "DssVest/add-overflow")                ||
+                uint128(award.rxd + amt) != (award.rxd + amt)                         && cmpStr(errmsg, "DssVest/uint128-overflow")            ||
+                gem.balanceOf(address(multisig)) < amt                                && cmpStr(errmsg, "gem/insufficient-balance")
+                                                                                      && cmpStr(errmsg, "DssVestTransferable/failed-transfer") ||
                 gem.allowance(address(multisig), address(tVest)) != type(uint256).max &&
                 gem.allowance(address(multisig), address(tVest)) < amt                && cmpStr(errmsg, "gem/insufficient-allowance")
+                                                                                      && cmpStr(errmsg, "DssVestTransferable/failed-transfer")
+
             );
         } catch {
             assert(

--- a/echidna/DssVestTransferrableEchidnaTest.sol
+++ b/echidna/DssVestTransferrableEchidnaTest.sol
@@ -2,23 +2,12 @@
 
 pragma solidity 0.6.12;
 
-import {DssVestTransferrable} from "../src/DssVest.sol";
+import {DssVest, DssVestTransferrable} from "../src/DssVest.sol";
 import                  {Dai} from "./Dai.sol";
 
 interface Hevm {
     function store(address, bytes32, bytes32) external;
     function load(address, bytes32) external returns (bytes32);
-}
-
-struct Award {
-    address usr;   // Vesting recipient
-    uint48  bgn;   // Start of vesting period  [timestamp]
-    uint48  clf;   // The cliff date           [timestamp]
-    uint48  fin;   // End of vesting period    [timestamp]
-    address mgr;   // A manager address that can yank
-    uint8   res;   // Restricted
-    uint128 tot;   // Total reward amount
-    uint128 rxd;   // Amount of vest claimed
 }
 
 /// @dev A contract that will receive Dai, and allows for it to be retrieved.
@@ -174,7 +163,7 @@ contract DssVestTransferrableEchidnaTest {
 
     function vest(uint256 id) public {
         id = tVest.ids() == 0 ? id : id % tVest.ids();
-        Award memory award = Award({
+        DssVest.Award memory award = DssVest.Award({
             usr: tVest.usr(id),
             bgn: toUint48(tVest.bgn(id)),
             clf: toUint48(tVest.clf(id)),
@@ -235,7 +224,7 @@ contract DssVestTransferrableEchidnaTest {
 
     function vest_amt(uint256 id, uint256 maxAmt) public {
         id = tVest.ids() == 0 ? id : id % tVest.ids();
-        Award memory award = Award({
+        DssVest.Award memory award = DssVest.Award({
             usr: tVest.usr(id),
             bgn: toUint48(tVest.bgn(id)),
             clf: toUint48(tVest.clf(id)),

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -408,7 +408,7 @@ contract DssVestMintable is DssVest {
         @param _gem The contract address of the mintable token
     */
     constructor(address _gem) public DssVest() {
-        require(_gem != address(0), "DssVest/Invalid-token-address");
+        require(_gem != address(0), "DssVestMintable/Invalid-token-address");
         gem = MintLike(_gem);
     }
 
@@ -435,7 +435,7 @@ contract DssVestSuckable is DssVest {
         @param _chainlog The contract address of the MCD chainlog
     */
     constructor(address _chainlog) public DssVest() {
-        require(_chainlog != address(0), "DssVest/Invalid-chainlog-address");
+        require(_chainlog != address(0), "DssVestSuckable/Invalid-chainlog-address");
         ChainlogLike chainlog_ = chainlog = ChainlogLike(_chainlog);
         VatLike vat_ = vat = VatLike(chainlog_.getAddress("MCD_VAT"));
         DaiJoinLike daiJoin_ = daiJoin = DaiJoinLike(chainlog_.getAddress("MCD_JOIN_DAI"));
@@ -471,8 +471,8 @@ contract DssVestTransferrable is DssVest {
         @param _gem  The token to be distributed
     */
     constructor(address _czar, address _gem) public DssVest() {
-        require(_czar != address(0), "DssVest/Invalid-distributor-address");
-        require(_gem  != address(0), "DssVest/Invalid-token-address");
+        require(_czar != address(0), "DssVestTransferrable/Invalid-distributor-address");
+        require(_gem  != address(0), "DssVestTransferrable/Invalid-token-address");
         czar = _czar;
         gem  = TokenLike(_gem);
     }

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -430,8 +430,6 @@ contract DssVestSuckable is DssVest {
     VatLike      public immutable vat;
     DaiJoinLike  public immutable daiJoin;
 
-    event Cage();
-
     /**
         @dev This contract must be authorized to 'suck' on the vat
         @param _chainlog The contract address of the MCD chainlog
@@ -446,20 +444,12 @@ contract DssVestSuckable is DssVest {
     }
 
     /**
-        @dev Permissionless 'live' Circuit Breaker by relying on existing mutex `lock` check
-    */
-    function cage() external {
-        require(vat.live() == 0, "DssVestSuckable/vat-still-live");
-        locked = 1;
-        emit Cage();
-    }
-
-    /**
         @dev Override pay to handle suck logic
         @param _guy The recipient of the ERC-20 Dai
         @param _amt The amount of Dai to send to the _guy [WAD]
     */
     function pay(address _guy, uint256 _amt) override internal {
+        require(vat.live() == 1, "DssVestSuckable/vat-not-live");
         vat.suck(chainlog.getAddress("MCD_VOW"), address(this), mul(_amt, RAY));
         daiJoin.exit(_guy, _amt);
     }

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -430,7 +430,7 @@ contract DssVestSuckable is DssVest {
     VatLike      public immutable vat;
     DaiJoinLike  public immutable daiJoin;
 
-    event Kill();
+    event Cage();
 
     /**
         @dev This contract must be authorized to 'suck' on the vat
@@ -446,12 +446,12 @@ contract DssVestSuckable is DssVest {
     }
 
     /**
-        @dev Permissionless 'live' Circuit Breaker
+        @dev Permissionless 'live' Circuit Breaker by relying on existing mutex `lock` check
     */
-    function kill() external {
+    function cage() external {
         require(vat.live() == 0, "DssVestSuckable/vat-still-live");
         locked = 1;
-        emit Kill();
+        emit Cage();
     }
 
     /**

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -34,6 +34,7 @@ interface DaiJoinLike {
 interface VatLike {
     function hope(address) external;
     function suck(address, address, uint256) external;
+    function live() external view returns (uint256);
 }
 
 interface TokenLike {
@@ -429,6 +430,8 @@ contract DssVestSuckable is DssVest {
     VatLike      public immutable vat;
     DaiJoinLike  public immutable daiJoin;
 
+    event Kill();
+
     /**
         @dev This contract must be authorized to 'suck' on the vat
         @param _chainlog The contract address of the MCD chainlog
@@ -440,6 +443,15 @@ contract DssVestSuckable is DssVest {
         DaiJoinLike daiJoin_ = daiJoin = DaiJoinLike(chainlog_.getAddress("MCD_JOIN_DAI"));
 
         vat_.hope(address(daiJoin_));
+    }
+
+    /**
+        @dev Permissionless 'live' Circuit Breaker
+    */
+    function kill() external {
+        require(vat.live() == 0, "DssVestSuckable/vat-still-live");
+        locked = 1;
+        emit Kill();
     }
 
     /**

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -483,6 +483,6 @@ contract DssVestTransferrable is DssVest {
         @param _amt The amount of gem to send to the _guy (in native token units)
     */
     function pay(address _guy, uint256 _amt) override internal {
-        require(gem.transferFrom(czar, _guy, _amt));
+        require(gem.transferFrom(czar, _guy, _amt), "DssVestTransferrable/failed-transfer");
     }
 }

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -76,17 +76,6 @@ contract User {
 }
 
 contract DssVestTest is DSTest {
-    struct Award {
-        address usr;   // Vesting recipient
-        uint48  bgn;   // Start of vesting period  [timestamp]
-        uint48  clf;   // The cliff date           [timestamp]
-        uint48  fin;   // End of vesting period    [timestamp]
-        address mgr;   // A manager address that can yank
-        uint8   res;   // Restricted
-        uint128 tot;   // Total reward amount
-        uint128 rxd;   // Amount of vest claimed
-    }
-
     // --- Math ---
     uint256 constant WAD = 10**18;
     uint256 constant RAY = 10**27;
@@ -883,9 +872,9 @@ contract DssVestTest is DSTest {
         sVest.vest(sId, 5 * days_vest);
         tVest.vest(tId, 5 * days_vest);
 
-        Award memory mmemaward = testUnpackAward(address(mVest), mId);
-        Award memory smemaward = testUnpackAward(address(sVest), sId);
-        Award memory tmemaward = testUnpackAward(address(tVest), tId);
+        DssVest.Award memory mmemaward = testUnpackAward(address(mVest), mId);
+        DssVest.Award memory smemaward = testUnpackAward(address(sVest), sId);
+        DssVest.Award memory tmemaward = testUnpackAward(address(tVest), tId);
 
         // Assert usr = slot 0x1 offset 0 awards.usr
         assertEq(mVest.usr(mId), mmemaward.usr);
@@ -928,7 +917,7 @@ contract DssVestTest is DSTest {
         assertEq(tVest.rxd(tId), uint256(tmemaward.rxd));
     }
 
-    function testUnpackAward(address vest, uint256 id) internal returns (Award memory award) {
+    function testUnpackAward(address vest, uint256 id) internal returns (DssVest.Award memory award) {
         // Load memory slot 0x1 offset 0
         bytes32 awardsPacked0x10 = hevm.load(address(vest), keccak256(abi.encode(uint256(id), uint256(1))));
 
@@ -991,7 +980,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(uint128(memrxd)), 5 * days_vest);             // Assert slot awards.rxd == 5 * days_vest
 
         return (
-            Award({
+            DssVest.Award({
                 usr: address(uint160(memusr)),
                 bgn:  uint48(membgn),
                 clf:  uint48(memclf),

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -24,6 +24,13 @@ interface EndLike {
 
 interface GemLike {
     function approve(address, uint256) external returns (bool);
+}
+
+interface DaiLike is GemLike {
+    function balanceOf(address) external returns (uint256);
+}
+
+interface DSTokenLike {
     function balanceOf(address) external returns (uint256);
 }
 
@@ -97,10 +104,10 @@ contract DssVestTest is DSTest {
     Manager                   boss;
 
     ChainlogLike          chainlog;
-    GemLike                    gem;
+    DSTokenLike                gem;
     MkrAuthorityLike     authority;
     VatLike                    vat;
-    GemLike                    dai;
+    DaiLike                    dai;
     EndLike                    end;
 
     address                    VOW;
@@ -109,10 +116,10 @@ contract DssVestTest is DSTest {
         hevm = Hevm(address(CHEAT_CODE));
 
          chainlog = ChainlogLike(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
-              gem = GemLike        (      chainlog.getAddress("MCD_GOV"));
+              gem = DSTokenLike    (      chainlog.getAddress("MCD_GOV"));
         authority = MkrAuthorityLike(     chainlog.getAddress("GOV_GUARD"));
               vat = VatLike(              chainlog.getAddress("MCD_VAT"));
-              dai = GemLike(              chainlog.getAddress("MCD_DAI"));
+              dai = DaiLike(              chainlog.getAddress("MCD_DAI"));
               end = EndLike(              chainlog.getAddress("MCD_END"));
               VOW =                       chainlog.getAddress("MCD_VOW");
 

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -11,7 +11,7 @@ interface Hevm {
     function load(address, bytes32) external returns (bytes32);
 }
 
-interface EndLikeTest {
+interface EndAbstract {
     function cage() external;
     function thaw() external;
     function wait() external returns (uint256);
@@ -29,19 +29,16 @@ struct Award {
     uint128 rxd;   // Amount of vest claimed
 }
 
-interface GemLike {
+interface DSTokenAbstract {
     function approve(address, uint256) external returns (bool);
-}
-
-interface GovGuard {
-    function wards(address) external returns (uint256);
-}
-
-interface Token {
     function balanceOf(address) external returns (uint256);
 }
 
-interface VatLikeTest {
+interface MkrAuthorityAbstract {
+    function wards(address) external returns (uint256);
+}
+
+interface VatAbstract {
     function wards(address) external view returns (uint256);
     function sin(address) external view returns (uint256);
     function debt() external view returns (uint256);
@@ -53,7 +50,7 @@ contract Manager {
     }
 
     function gemApprove(address gem, address spender) external {
-        GemLike(gem).approve(spender, type(uint256).max);
+        DSTokenAbstract(gem).approve(spender, type(uint256).max);
     }
 }
 
@@ -78,67 +75,80 @@ contract User {
 }
 
 contract DssVestTest is DSTest {
-    Hevm hevm;
-    DssVestMintable      mVest;
-    DssVestSuckable      sVest;
-    DssVestTransferrable tVest;
-    Manager boss;
-
-    address constant MKR_TOKEN = 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2;
-    address constant CHAINLOG = 0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F;
-    address constant VAT = 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B;
-    address constant DAI_JOIN = 0x9759A6Ac90977b93B58547b4A71c78317f391A28;
-    address constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
-    address constant VOW = 0xA950524441892A31ebddF91d3cEEFa04Bf454466;
-    address constant END = 0xBB856d1742fD182a90239D7AE85706C2FE4e5922;
+    // --- Math ---
     uint256 constant WAD = 10**18;
     uint256 constant RAY = 10**27;
     uint256 constant days_vest = WAD;
+
+    // --- Hevm ---
+    Hevm hevm;
 
     // CHEAT_CODE = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D
     bytes20 constant CHEAT_CODE =
         bytes20(uint160(uint256(keccak256('hevm cheat code'))));
 
-    address GOV_GUARD = 0x6eEB68B2C7A918f36B78E2DB80dcF279236DDFb8;
+    DssVestMintable          mVest;
+    DssVestSuckable          sVest;
+    DssVestTransferrable     tVest;
+    Manager                   boss;
+
+    ChainlogLike          chainlog;
+    DSTokenAbstract            gem;
+    MkrAuthorityAbstract authority;
+    VatAbstract                vat;
+    DSTokenAbstract            dai;
+    EndAbstract                end;
+
+    address                    VOW;
 
     function setUp() public {
         hevm = Hevm(address(CHEAT_CODE));
-        mVest = new DssVestMintable(MKR_TOKEN);
+
+         chainlog = ChainlogLike(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
+              gem = DSTokenAbstract(      chainlog.getAddress("MCD_GOV"));
+        authority = MkrAuthorityAbstract( chainlog.getAddress("GOV_GUARD"));
+              vat = VatAbstract(          chainlog.getAddress("MCD_VAT"));
+              dai = DSTokenAbstract(      chainlog.getAddress("MCD_DAI"));
+              end = EndAbstract(          chainlog.getAddress("MCD_END"));
+              VOW =                       chainlog.getAddress("MCD_VOW");
+
+        mVest = new DssVestMintable(address(gem));
         mVest.file("cap", (2000 * WAD) / (4 * 365 days));
-        sVest = new DssVestSuckable(CHAINLOG);
+        sVest = new DssVestSuckable(address(chainlog));
         sVest.file("cap", (2000 * WAD) / (4 * 365 days));
         boss = new Manager();
-        tVest = new DssVestTransferrable(address(boss), address(DAI));
+        tVest = new DssVestTransferrable(address(boss), address(dai));
         tVest.file("cap", (2000 * WAD) / (4 * 365 days));
-        boss.gemApprove(address(DAI), address(tVest));
+        boss.gemApprove(address(dai), address(tVest));
+
 
         // Set testing contract as a MKR Auth
         hevm.store(
-            address(GOV_GUARD),
+            address(authority),
             keccak256(abi.encode(address(mVest), uint256(1))),
             bytes32(uint256(1))
         );
-        assertEq(GovGuard(GOV_GUARD).wards(address(mVest)), 1);
+        assertEq(authority.wards(address(mVest)), 1);
 
         // Give admin access to vat
         hevm.store(
-            address(VAT),
+            address(vat),
             keccak256(abi.encode(address(sVest), uint256(0))),
             bytes32(uint256(1))
         );
-        assertEq(VatLikeTest(VAT).wards(address(sVest)), 1);
+        assertEq(vat.wards(address(sVest)), 1);
 
         // Give boss 10000 DAI
         hevm.store(
-            address(DAI),
+            address(dai),
             keccak256(abi.encode(address(boss), uint(2))),
             bytes32(uint256(10000 * WAD))
         );
-        assertEq(Token(DAI).balanceOf(address(boss)), 10000 * WAD);
+        assertEq(dai.balanceOf(address(boss)), 10000 * WAD);
     }
 
     function testCost() public {
-        new DssVestMintable(MKR_TOKEN);
+        new DssVestMintable(address(gem));
     }
 
     function testInit() public {
@@ -164,7 +174,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(fin), now + 90 days);
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 0);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 0);
+        assertEq(gem.balanceOf(address(this)), 0);
 
         mVest.vest(id);
         (usr, bgn, clf, fin, mgr,, tot, rxd) = mVest.awards(id);
@@ -173,7 +183,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(fin), now + 90 days);
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 10 * days_vest);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 10 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 10 * days_vest);
 
         hevm.warp(now + 70 days);
 
@@ -184,7 +194,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(fin), now + 20 days);
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 80 * days_vest);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 80 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 80 * days_vest);
     }
 
     function testFailVestNonExistingAward() public {
@@ -205,7 +215,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 0);
         assertEq(mgr, address(0));
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 0);
+        assertEq(gem.balanceOf(address(this)), 0);
     }
 
     function testVestAfterTimeout() public {
@@ -219,7 +229,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(fin), now - 100 days);
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 0);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 0);
+        assertEq(gem.balanceOf(address(this)), 0);
 
         mVest.vest(id);
         (usr, bgn, clf, fin, mgr,, tot, rxd) = mVest.awards(id);
@@ -229,7 +239,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(fin), now - 100 days);
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 100 * days_vest);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 100*days_vest);
+        assertEq(gem.balanceOf(address(this)), 100*days_vest);
         assertTrue(!mVest.valid(id));
     }
 
@@ -259,16 +269,16 @@ contract DssVestTest is DSTest {
         assertEq(mVest.unpaid(id), days_vest * 4);       // past cliff
         mVest.vest(id);
         assertEq(mVest.unpaid(id), 0);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), days_vest * 4);
+        assertEq(gem.balanceOf(address(this)), days_vest * 4);
         hevm.warp(block.timestamp + 10 days);
         assertEq(mVest.unpaid(id), days_vest * 10);
         mVest.vest(id);
         assertEq(mVest.unpaid(id), 0);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), days_vest * 14);
+        assertEq(gem.balanceOf(address(this)), days_vest * 14);
         hevm.warp(block.timestamp + 120 days);           // vesting complete
         assertEq(mVest.unpaid(id), days_vest * 86);
         mVest.vest(id);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 100 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 100 * days_vest);
     }
 
     function testAccrued() public {
@@ -288,19 +298,19 @@ contract DssVestTest is DSTest {
         mVest.vest(id);
         assertEq(mVest.unpaid(id), 0);
         assertEq(mVest.accrued(id), days_vest * 4);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), days_vest * 4);
+        assertEq(gem.balanceOf(address(this)), days_vest * 4);
         hevm.warp(block.timestamp + 10 days);
         assertEq(mVest.unpaid(id), days_vest * 10);
         assertEq(mVest.accrued(id), days_vest * 14);
         mVest.vest(id);
         assertEq(mVest.unpaid(id), 0);
         assertEq(mVest.accrued(id), days_vest * 14);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), days_vest * 14);
-        hevm.warp(block.timestamp + 120 days);       // vesting complete
+        assertEq(gem.balanceOf(address(this)), days_vest * 14);
+        hevm.warp(block.timestamp + 120 days);           // vesting complete
         assertEq(mVest.unpaid(id), days_vest * 86);
         assertEq(mVest.accrued(id), days_vest * 100);
         mVest.vest(id);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 100 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 100 * days_vest);
     }
 
     function testFutureAccrual() public {
@@ -330,9 +340,9 @@ contract DssVestTest is DSTest {
         assertEq(fin, block.timestamp);
         assertEq(uint256(tot), 100 * days_vest * 2 / 100);
         assertTrue(mVest.valid(id));
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 0);
+        assertEq(gem.balanceOf(address(this)), 0);
         mVest.vest(id);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 2 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 2 * days_vest);
         assertTrue(!mVest.valid(id));
     }
 
@@ -391,7 +401,7 @@ contract DssVestTest is DSTest {
         hevm.warp(block.timestamp + 999 days);
         mVest.vest(id); // user collects at some future time
         assertTrue(!mVest.valid(id));
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 2 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 2 * days_vest);
     }
 
     function testYankAfterVest() public {
@@ -401,7 +411,7 @@ contract DssVestTest is DSTest {
         hevm.warp(block.timestamp + 2 days);
         assertEq(mVest.unpaid(id), 2 * days_vest);
         mVest.vest(id); // collect some now
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 2 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 2 * days_vest);
 
         hevm.warp(block.timestamp + 2 days);
         assertEq(mVest.unpaid(id), 2 * days_vest);
@@ -417,7 +427,7 @@ contract DssVestTest is DSTest {
         assertEq(mVest.accrued(id), 4 * days_vest);
         mVest.vest(id); // user collects at some future time
         assertTrue(!mVest.valid(id));
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 4 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 4 * days_vest);
     }
 
     function testYankSchedulePassed() public {
@@ -436,7 +446,7 @@ contract DssVestTest is DSTest {
         assertEq(mVest.accrued(id), 51 * days_vest);
         mVest.vest(id); // user collects at some future time
         assertTrue(!mVest.valid(id));
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 51 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 51 * days_vest);
     }
 
     function testYankScheduleFutureAfterCliff() public {
@@ -455,7 +465,7 @@ contract DssVestTest is DSTest {
         assertEq(mVest.accrued(id), 21 * days_vest);
         mVest.vest(id); // user collects at some future time
         assertTrue(!mVest.valid(id));
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 21 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 21 * days_vest);
     }
 
     function testYankScheduleFutureBeforeCliff() public {
@@ -472,7 +482,7 @@ contract DssVestTest is DSTest {
         assertEq(mVest.accrued(id), 0);
         mVest.vest(id); // user collects at some future time
         assertTrue(!mVest.valid(id));
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 0);
+        assertEq(gem.balanceOf(address(this)), 0);
     }
 
     function testYankScheduleFutureAfterCompletion() public {
@@ -493,7 +503,7 @@ contract DssVestTest is DSTest {
         assertEq(mVest.accrued(id), 100 * days_vest);
         mVest.vest(id); // user collects at some future time
         assertTrue(!mVest.valid(id));
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 100 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 100 * days_vest);
     }
 
     function testMgrYank() public {
@@ -504,9 +514,9 @@ contract DssVestTest is DSTest {
         hevm.warp(block.timestamp + 30 days);
         manager.yank(address(mVest), id1);
         assertTrue(mVest.valid(id1));
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 0);
+        assertEq(gem.balanceOf(address(this)), 0);
         mVest.vest(id1);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 30 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 30 * days_vest);
         assertTrue(!mVest.valid(id1));
 
         uint256 id2 = mVest.create(address(this), 100 * days_vest, block.timestamp, 100 days, 30 days, address(manager));
@@ -528,7 +538,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(fin), now + 90 days);
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 0);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 0);
+        assertEq(gem.balanceOf(address(this)), 0);
 
         alice.vest(address(mVest), id);
 
@@ -538,7 +548,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(fin), now + 90 days);
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 10 * days_vest);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 10 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 10 * days_vest);
 
         hevm.warp(now + 70 days);
 
@@ -549,7 +559,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(fin), now + 20 days);
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 80 * days_vest);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 80 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 80 * days_vest);
     }
 
     function testFailRestrictedVest() public {
@@ -564,7 +574,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(fin), now + 90 days);
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 0);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 0);
+        assertEq(gem.balanceOf(address(this)), 0);
 
         mVest.restrict(id);
 
@@ -642,32 +652,32 @@ contract DssVestTest is DSTest {
     }
 
     function testSuckableVest() public {
-        uint256 originalSin = VatLikeTest(VAT).sin(VOW);
+        uint256 originalSin = vat.sin(VOW);
         uint256 id = sVest.create(address(this), 100 * days_vest, block.timestamp, 100 days, 0, address(0));
         assertTrue(sVest.valid(id));
         hevm.warp(block.timestamp + 1 days);
         sVest.vest(id);
-        assertEq(Token(DAI).balanceOf(address(this)), 1 * days_vest);
-        assertEq(VatLikeTest(VAT).sin(VOW), originalSin + 1 * days_vest * RAY);
+        assertEq(dai.balanceOf(address(this)), 1 * days_vest);
+        assertEq(vat.sin(VOW), originalSin + 1 * days_vest * RAY);
         hevm.warp(block.timestamp + 9 days);
         sVest.vest(id);
-        assertEq(Token(DAI).balanceOf(address(this)), 10 * days_vest);
-        assertEq(VatLikeTest(VAT).sin(VOW), originalSin + 10 * days_vest * RAY);
+        assertEq(dai.balanceOf(address(this)), 10 * days_vest);
+        assertEq(vat.sin(VOW), originalSin + 10 * days_vest * RAY);
         hevm.warp(block.timestamp + 365 days);
         sVest.vest(id);
-        assertEq(Token(DAI).balanceOf(address(this)), 100 * days_vest);
-        assertEq(VatLikeTest(VAT).sin(VOW), originalSin + 100 * days_vest * RAY);
+        assertEq(dai.balanceOf(address(this)), 100 * days_vest);
+        assertEq(vat.sin(VOW), originalSin + 100 * days_vest * RAY);
     }
 
     function testSuckableVestKill() public {
-        uint256 originalSin = VatLikeTest(VAT).sin(VOW);
+        uint256 originalSin = vat.sin(VOW);
         uint256 id = sVest.create(address(this), 100 * days_vest, block.timestamp, 100 days, 0, address(0));
         assertTrue(sVest.valid(id));
 
         hevm.warp(block.timestamp + 1 days);
         sVest.vest(id);
-        assertEq(Token(DAI).balanceOf(address(this)), 1 * days_vest);
-        assertEq(VatLikeTest(VAT).sin(VOW), originalSin + 1 * days_vest * RAY);
+        assertEq(dai.balanceOf(address(this)), 1 * days_vest);
+        assertEq(vat.sin(VOW), originalSin + 1 * days_vest * RAY);
 
         hevm.warp(block.timestamp + 9 days);
 
@@ -682,11 +692,11 @@ contract DssVestTest is DSTest {
 
         // Get End auth to allow call `cage`
         hevm.store(
-            END,
+            address(end),
             keccak256(abi.encode(address(this), uint256(0))),
             bytes32(uint256(1))
         );
-        EndLikeTest(END).cage();
+        end.cage();
 
         uint256 when = block.timestamp;
 
@@ -697,25 +707,25 @@ contract DssVestTest is DSTest {
         } catch Error(string memory errmsg) {
             bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));             // Load memory slot 0x4 (locked)
             assertTrue(uint256(sLocked) == 1 && cmpStr(errmsg, "DssVest/system-locked")); // Assert slot locked == 1 and vest reverts
-            assertEq(Token(DAI).balanceOf(address(this)), 1 * days_vest);
-            assertEq(VatLikeTest(VAT).sin(VOW), 0);
+            assertEq(dai.balanceOf(address(this)), 1 * days_vest);
+            assertEq(vat.sin(VOW), 0);
         } catch {
             assertTrue(false);
         }
 
-        hevm.warp(when + EndLikeTest(END).wait());
-        uint256 vatDebt = VatLikeTest(VAT).debt();
+        hevm.warp(when + end.wait());
+        uint256 vatDebt = vat.debt();
 
         // Coerce system surplus to zero to allow end `thaw` execution
         hevm.store(
-            VAT,
+            address(vat),
             keccak256(abi.encode(address(VOW), uint256(5))),
             bytes32(uint256(0))
         );
 
-        EndLikeTest(END).thaw();
+        end.thaw();
 
-        uint256 endDebt = EndLikeTest(END).debt();
+        uint256 endDebt = end.debt();
         assertEq(endDebt, vatDebt);
     }
 
@@ -752,7 +762,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 0);
         assertEq(mVest.unpaid(id), 10 * days_vest);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 0);
+        assertEq(gem.balanceOf(address(this)), 0);
 
         mVest.vest(id, 5 * days_vest);
 
@@ -763,7 +773,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 5 * days_vest);
         assertEq(mVest.unpaid(id), 5 * days_vest);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 5 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 5 * days_vest);
 
         // Additional partial vesting calls, up to the entire amount owed at this time
         mVest.vest(id, 3 * days_vest);
@@ -775,7 +785,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 8 * days_vest);
         assertEq(mVest.unpaid(id), 2 * days_vest);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 8 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 8 * days_vest);
 
         mVest.vest(id, 2 * days_vest);
 
@@ -786,7 +796,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 10 * days_vest);
         assertEq(mVest.unpaid(id), 0);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 10 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 10 * days_vest);
 
         // Another partial vesting after subsequent elapsed time
         hevm.warp(now + 40 days);
@@ -798,7 +808,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 10 * days_vest);
         assertEq(mVest.unpaid(id), 40 * days_vest);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 10 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 10 * days_vest);
 
         mVest.vest(id, 20 * days_vest);
 
@@ -809,7 +819,7 @@ contract DssVestTest is DSTest {
         assertEq(uint256(tot), 100 * days_vest);
         assertEq(uint256(rxd), 30 * days_vest);
         assertEq(mVest.unpaid(id), 20 * days_vest);
-        assertEq(Token(address(mVest.gem())).balanceOf(address(this)), 30 * days_vest);
+        assertEq(gem.balanceOf(address(this)), 30 * days_vest);
     }
 
     function testTransferrableVest() public {
@@ -827,20 +837,20 @@ contract DssVestTest is DSTest {
         assertTrue(tVest.valid(id));
         hevm.warp(block.timestamp + 1 days);
         tVest.vest(id);
-        assertEq(Token(DAI).balanceOf(address(usr)), 1 * days_vest);
-        assertEq(Token(DAI).balanceOf(address(boss)), 10000 * WAD - 1 * days_vest);
+        assertEq(dai.balanceOf(address(usr)), 1 * days_vest);
+        assertEq(dai.balanceOf(address(boss)), 10000 * WAD - 1 * days_vest);
         hevm.warp(block.timestamp + 9 days);
         tVest.vest(id);
-        assertEq(Token(DAI).balanceOf(address(usr)), 10 * days_vest);
-        assertEq(Token(DAI).balanceOf(address(boss)), 10000 * WAD - 10 * days_vest);
+        assertEq(dai.balanceOf(address(usr)), 10 * days_vest);
+        assertEq(dai.balanceOf(address(boss)), 10000 * WAD - 10 * days_vest);
         hevm.warp(block.timestamp + 365 days);
         tVest.vest(id);
-        assertEq(Token(DAI).balanceOf(address(usr)), 100 * days_vest);
-        assertEq(Token(DAI).balanceOf(address(boss)), 10000 * WAD - 100 * days_vest);
+        assertEq(dai.balanceOf(address(usr)), 100 * days_vest);
+        assertEq(dai.balanceOf(address(boss)), 10000 * WAD - 100 * days_vest);
         hevm.warp(block.timestamp + 365 days);
         tVest.vest(id);
-        assertEq(Token(DAI).balanceOf(address(usr)), 100 * days_vest);
-        assertEq(Token(DAI).balanceOf(address(boss)), 10000 * WAD - 100 * days_vest);
+        assertEq(dai.balanceOf(address(usr)), 100 * days_vest);
+        assertEq(dai.balanceOf(address(boss)), 10000 * WAD - 100 * days_vest);
     }
 
     function testWardsSlot0x0() public {

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -669,7 +669,7 @@ contract DssVestTest is DSTest {
         assertEq(vat.sin(VOW), originalSin + 100 * days_vest * RAY);
     }
 
-    function testSuckableVestKill() public {
+    function testSuckableVestCage() public {
         uint256 originalSin = vat.sin(VOW);
         uint256 id = sVest.create(address(this), 100 * days_vest, block.timestamp, 100 days, 0, address(0));
         assertTrue(sVest.valid(id));
@@ -681,11 +681,11 @@ contract DssVestTest is DSTest {
 
         hevm.warp(block.timestamp + 9 days);
 
-        try sVest.kill() {
+        try sVest.cage() {
             assertTrue(false);
         } catch Error(string memory errmsg) {
             bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));                      // Load memory slot 0x4 (locked)
-            assertTrue(uint256(sLocked) == 0 && cmpStr(errmsg, "DssVestSuckable/vat-still-live")); // Assert slot locked == 0 and kill reverts
+            assertTrue(uint256(sLocked) == 0 && cmpStr(errmsg, "DssVestSuckable/vat-still-live")); // Assert slot locked == 0 and cage reverts
         } catch {
             assertTrue(false);
         }
@@ -700,13 +700,13 @@ contract DssVestTest is DSTest {
 
         uint256 when = block.timestamp;
 
-        sVest.kill();
+        sVest.cage();
 
         try sVest.vest(id) {
             assertTrue(false);
         } catch Error(string memory errmsg) {
-            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));             // Load memory slot 0x4 (locked)
-            assertTrue(uint256(sLocked) == 1 && cmpStr(errmsg, "DssVest/system-locked")); // Assert slot locked == 1 and vest reverts
+            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));                      // Load memory slot 0x4 (locked)
+            assertTrue(uint256(sLocked) == 1 && cmpStr(errmsg, "DssVest/system-locked"));          // Assert slot locked == 1 and vest reverts
             assertEq(dai.balanceOf(address(this)), 1 * days_vest);
             assertEq(vat.sin(VOW), 0);
         } catch {
@@ -730,7 +730,7 @@ contract DssVestTest is DSTest {
     }
 
     function testFailNotCaged() public {
-        sVest.kill();
+        sVest.cage();
     }
 
     function testCap() public {

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -697,7 +697,7 @@ contract DssVestTest is DSTest {
         } catch Error(string memory errmsg) {
             assertTrue(vat.live() == 0 && cmpStr(errmsg, "DssVestSuckable/vat-not-live"));
             assertEq(dai.balanceOf(address(this)), 1 * days_vest);
-            assertEq(vat.sin(VOW), 0);
+            assertEq(vat.sin(VOW), 0); // true only if there is more surplus than debt in the system
         } catch {
             assertTrue(false);
         }


### PR DESCRIPTION
- [x] Add `vat.live` check to `DssVestSuckable` `pay`
	- Prior Explored Approaches: https://hackmd.io/@naszam/Sy1SOo1M9
- [x] Refactor Tests 
	- [x]  fetch from ChainLog
	- [x]  split interfaces for contract and tests
- [x] Add Fuzz Coverage (Update Echidna Tests)
- [x] Add FV Coverage (Update Certora Specs)
- [x] Document `vat.suck` circuit breaker in the readme
- [x] Minor Changes