### PR TITLE
update action version

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'
           java-package: jre
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/echidna.yml
+++ b/.github/workflows/echidna.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -40,7 +40,7 @@ jobs:
           jq --sort-keys . crytic-export/combined_solc.json > sorted_crytic_solc.json
 
       - name: Cache ${{ matrix.testName }} Corpus
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: corpus
           key: abi-${{ matrix.testName }}-${{ hashFiles('**/sorted_crytic_solc.json') }}-v3
@@ -60,7 +60,7 @@ jobs:
           echidna-version: v2.0.0
 
       - name: Upload ${{ matrix.testName }} Coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverage-${{ matrix.testName }}
           path: corpus/covered.*


### PR DESCRIPTION
We'll need to update the GitHub actions that rely on node12 since it's deprecated now. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

cc @eskp @sanbotto @OleksandrUA @cristidas @jeannettemcd @zdumitru